### PR TITLE
Fix relation for auction price variant

### DIFF
--- a/app/Models/RfqVendorAuctionPrice.php
+++ b/app/Models/RfqVendorAuctionPrice.php
@@ -10,6 +10,8 @@ class RfqVendorAuctionPrice extends Model
 
     public function rfqProductVariant()
     {
-        return $this->belongsTo(RfqProductVariant::class, 'rfq_product_variant_id');
+        // Database column is misspelled as `rfq_product_veriant_id`
+        // so we need to reference it explicitly here.
+        return $this->belongsTo(RfqProductVariant::class, 'rfq_product_veriant_id');
     }
 }


### PR DESCRIPTION
## Summary
- Ensure `RfqVendorAuctionPrice` model uses correct foreign key column (`rfq_product_veriant_id`) for product variant relation to prevent SQL errors when retrieving vendor auction data.

## Testing
- `phpunit` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2642e6d88327b5bad910c03aa81e