### PR TITLE
Add live metrics refresh for lot-wise auction

### DIFF
--- a/resources/views/vendor/live-auction/auction-rfq-reply-lot-wise.blade.php
+++ b/resources/views/vendor/live-auction/auction-rfq-reply-lot-wise.blade.php
@@ -747,6 +747,49 @@ function rfq_counter_submit_data(_this, action) {
 }
 </script>
 
+<script>
+// Auto-fetch L1 price and rank every 2 minutes
+$(function(){
+    const rfqId = $("input[name='rfq_id']").val();
+    if(!rfqId) return;
+
+    const POLL_MS = 120000; // 2 minutes
+
+    function fmtPrice(n){
+        return n == null ? '-' : IND_amount_format(Number(n).toFixed(2));
+    }
+
+    function render(data){
+        $('#l1Price').text(fmtPrice(data.l1));
+
+        const $rank = $('#yourRank');
+        if(data.rank == null){
+            $rank.text('-').removeClass('text-success text-warning text-danger');
+        } else {
+            $rank.text(data.rank).removeClass('text-success text-warning text-danger');
+            if(data.rank === 1) $rank.addClass('text-success');
+            else if(data.rank <= 3) $rank.addClass('text-warning');
+            else $rank.addClass('text-danger');
+        }
+    }
+
+    function fetchMetrics(){
+        $.post('{{ route('vendor.live-auction.rfq.total-metrics') }}', {
+            _token: '{{ csrf_token() }}',
+            rfq_id: rfqId
+        }).done(function(res){
+            if(res && res.status && res.data){
+                render(res.data);
+            }
+        });
+    }
+
+    fetchMetrics();
+    setInterval(fetchMetrics, POLL_MS);
+    $(document).on('visibilitychange', function(){ if(!document.hidden) fetchMetrics(); });
+});
+</script>
+
 <!-- ====== LIVE + COUNTDOWN TIMER ====== -->
 <script>
 (function(){

--- a/routes/vendor.php
+++ b/routes/vendor.php
@@ -80,7 +80,8 @@ Route::name('vendor.')->group(function() {
 
      
             Route::post('/live-auction/metrics',[LiveAuctionRfqController::class, 'liveMetrics'])->name('live-auction.rfq.metrics');
-            
+            Route::post('/live-auction/total-metrics',[LiveAuctionRfqSinglePriceController::class, 'liveMetricsTotal'])->name('live-auction.rfq.total-metrics');
+
             Route::post('/live-auction-singal-price/rfq/submit', [LiveAuctionRfqSinglePriceController::class, 'saveLotRfq'])->name('live-auction-singal-price.rfq.submit');
 
             


### PR DESCRIPTION
## Summary
- add endpoint to fetch L1 price and rank for total bids using single-price controller
- auto-refresh lot-wise live auction page via AJAX every 2 minutes
- restore live metrics endpoint in main live auction controller

## Testing
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb29dd75cc8327b25f34caa938e875