### PR TITLE
fix: handle 2 percent bid validation

### DIFF
--- a/resources/views/vendor/live-auction/auction-rfq-reply-lot-wise.blade.php
+++ b/resources/views/vendor/live-auction/auction-rfq-reply-lot-wise.blade.php
@@ -581,14 +581,14 @@ const validateTotalPrice = price => {
         return false;
     }
 
-    const maxAllowed = base * (1 - minDec / 100);
+    const maxAllowed = parseFloat((base * (1 - minDec / 100)).toFixed(2));
     if (price > maxAllowed) {
         showBidError(`Your bid must be at least ${minDec}% lower than the last price. Maximum allowed bid is ${maxAllowed.toFixed(2)}.`);
         $('#PriceInput').val('');
         return false;
     }
 
-    const minAllowed = base * (1 - (minDec + 10) / 100);
+    const minAllowed = parseFloat((base * (1 - (minDec + 10) / 100)).toFixed(2));
     if (price < minAllowed) {
         showBidError(`Your bid cannot be more than ${minDec + 10}% lower than the last price. Minimum allowed bid is ${minAllowed.toFixed(2)}.`);
         $('#PriceInput').val('');


### PR DESCRIPTION
## Summary
- round comparison bounds for auction bids to two decimals to prevent false rejections at exactly 2% below last price

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5d60150c832786bd311a820117d8