### PR TITLE
fix: correct lot bid start total check

### DIFF
--- a/app/Http/Controllers/Vendor/LiveAuctionRfqSinglePriceController.php
+++ b/app/Http/Controllers/Vendor/LiveAuctionRfqSinglePriceController.php
@@ -216,12 +216,12 @@ class LiveAuctionRfqSinglePriceController extends Controller
             $startTotal = $startTotalFromUI;
         }
 
-        // if ($startTotal > 0 && $lotPrice > $startTotal) {
-        //     return response()->json([
-        //         'status'=>false,
-        //         'message'=>'Your lot bid cannot exceed the Start Total ('.number_format($startTotal,2).').'
-        //     ]);
-        // }
+        if ($startTotal > 0 && $lotPrice > $startTotal) {
+            return response()->json([
+                'status'  => false,
+                'message' => 'Your lot bid cannot exceed the Start Total (' . number_format($startTotal, 2) . ').',
+            ]);
+        }
 
         $check = $this->checkRankByPrice(
             $rfqId,


### PR DESCRIPTION
## Summary
- enforce start total limit in RFQ single price controller

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/rv22/vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bc64a6040883278f05b22794a07334