### PR TITLE
Show disabled Close button in RFQ table

### DIFF
--- a/resources/views/buyer/auction/partials/table.blade.php
+++ b/resources/views/buyer/auction/partials/table.blade.php
@@ -147,13 +147,12 @@
                             {{ $rfq_button[$current_status] ?? 'View' }}
                         </a>
 
-                        @if ($show_close)
                         <a href="javascript:void(0)"
-                           class="ra-btn small-btn ra-btn-outline-danger close-auction"
+                           class="ra-btn small-btn ra-btn-outline-danger close-auction disabled"
+                           aria-disabled="true"
                            data-rfq="{{ $result->rfq_id }}">
                            Close
                         </a>
-                        @endif
                     </div>
                 </td>
             </tr>


### PR DESCRIPTION
## Summary
- Always display the Close button in RFQ action column but keep it disabled

## Testing
- ⚠️ `composer install --no-progress --no-scripts` (missing network access)
- ⚠️ `vendor/bin/phpunit` (vendor not installed)


------
https://chatgpt.com/codex/tasks/task_e_68bd8f55751c83278be0a7e207c8cd47