### PR TITLE
Enable close action for scheduled auctions

### DIFF
--- a/resources/views/buyer/auction/partials/table.blade.php
+++ b/resources/views/buyer/auction/partials/table.blade.php
@@ -148,8 +148,8 @@
                         </a>
 
                         <a href="javascript:void(0)"
-                           class="ra-btn small-btn ra-btn-outline-danger close-auction disabled"
-                           aria-disabled="true"
+                           class="ra-btn small-btn ra-btn-outline-danger close-auction {{ $show_close ? '' : 'disabled' }}"
+                           @unless($show_close) aria-disabled="true" @endunless
                            data-rfq="{{ $result->rfq_id }}">
                            Close
                         </a>


### PR DESCRIPTION
## Summary
- allow scheduled auctions to be closed by enabling the Close button when status is scheduled

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9059d0408327853f849a2b3e9059