### PR TITLE
Add force stop auction control to CIS view

### DIFF
--- a/app/Http/Controllers/Buyer/AuctionController.php
+++ b/app/Http/Controllers/Buyer/AuctionController.php
@@ -639,17 +639,17 @@ class AuctionController extends Controller
 
         $currentTime = date('H:i:s');
 
-        DB::table('rfq_auctions')
+        $updated = DB::table('rfq_auctions')
             ->where('rfq_no', $rfqNo)
             ->update([
                 'is_forcestop'     => '1',
                 'auction_end_time' => $currentTime
             ]);
 
-        if (DB::affectingStatement('SELECT ROW_COUNT()')) {
-            return response()->json(['status'=>'success','message'=>'Auction forcibly stopped successfully.']);
+        if ($updated) {
+            return response()->json(['status' => 'success', 'message' => 'Auction forcibly stopped successfully.']);
         }
-        return response()->json(['status'=>'error','message'=>'Failed to stop auction or auction already stopped.']);
+        return response()->json(['status' => 'error', 'message' => 'Failed to stop auction or auction already stopped.']);
     }
 
     

--- a/resources/views/buyer/auction/cis/rfq-cis.blade.php
+++ b/resources/views/buyer/auction/cis/rfq-cis.blade.php
@@ -50,7 +50,14 @@
                             <h1 class="text-primary-blue font-size-27 mb-0">Comparative Information Statement</h1>
                         </div>
 
-                        <!-- END (right): Refresh -->
+                        <!-- END (right): Controls -->
+                        @if(isset($current_status) && $current_status == 1)
+                        <div class="flex-shrink-0 ms-2">
+                            <a href="javascript:void(0);" class="btn btn-danger float-right mr-3 py-1 px-2" onclick="forceStopAuction('{{ $rfq['rfq_id'] }}')">
+                               <i class="bi bi-stop-circle"></i> Stop Auction
+                            </a>
+                        </div>
+                        @endif
                         <div class="flex-shrink-0 ms-2">
                             <button type="button" class="ra-btn ra-btn-outline-primary px-2 font-size-11" onclick="window.location.reload();">
                                 <span class="bi bi-arrow-clockwise font-size-12" aria-hidden="true"></span>
@@ -1147,5 +1154,28 @@
         $timer.textContent = hours + "h " + minutes + "m " + seconds + "s";
     }, 1000);
 })();
+</script>
+<script>
+function forceStopAuction(rfqNo) {
+    if (confirm("Are you sure you want to force stop this auction?")) {
+        fetch("{{ url('buyer/auction/force-stop') }}", {
+            method: 'POST',
+            headers: {
+                'X-CSRF-TOKEN': '{{ csrf_token() }}',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ rfq_no: rfqNo })
+        })
+        .then(response => response.json())
+        .then(response => {
+            if (response.status === 'success') {
+                toastr.success(response.message);
+                setTimeout(function () { window.location.reload(); }, 1000);
+            } else {
+                toastr.error(response.message);
+            }
+        });
+    }
+}
 </script>
 @endsection


### PR DESCRIPTION
## Summary
- allow buyer to forcibly end a live auction from CIS page
- simplify backend force-stop logic to return success based on update result

## Testing
- `php artisan test` *(fails: require(/workspace/rv22/vendor/autoload.php): No such file or directory)*
- `composer install` *(fails: curl error 56 while downloading packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bda54f6f8c8327ba814dc3d9f5beee