### PR TITLE
fix: guard auction relation in live auction table

### DIFF
--- a/resources/views/vendor/live-auction/partials/table.blade.php
+++ b/resources/views/vendor/live-auction/partials/table.blade.php
@@ -16,9 +16,12 @@
         @forelse ($results as $result)
         @php
             // --- Derive auction fields safely ---
-            $auction = $result->rfq_auction ?? null;
+            // Accessing related auction details can fail when the relation is missing
+            // (e.g. an RFQ was created without an auction).  Using the nullsafe
+            // operator avoids "Attempt to read property ... on null" errors.
+            $auction      = $result->rfq_auction ?? null;
             $rfqCreatedAt = $result->rfq_auction?->rfq?->created_at;
-            $rfqDate = $rfqCreatedAt ? date('d/m/Y', strtotime($rfqCreatedAt)) : '-';
+            $rfqDate      = $rfqCreatedAt ? date('d/m/Y', strtotime($rfqCreatedAt)) : '-';
             $auction_date = $auction->auction_date ?? null;            // 'Y-m-d'
             $auction_start = $auction->auction_start_time ?? null;     // 'H:i:s'
             $auction_end   = $auction->auction_end_time ?? null;       // 'H:i:s'
@@ -74,7 +77,8 @@
             <td class="align-middle">{{ $rfqDate }}</td>
             <td>
                 @php
-                    $variant = $result->rfq_auction->rfq_auction_variant->first();
+                    // Guard against missing auction relation when resolving product
+                    $variant = $auction?->rfq_auction_variant?->first();
                     $product = $variant?->product;
                 @endphp
                 @if($product)
@@ -85,8 +89,8 @@
                     -
                 @endif
             </td>
-            <td class="align-middle">{{ $result->rfq_auction->buyer->legal_name ?? '-' }}</td>
-            <td class="align-middle">{{ $result->rfq_auction->buyer->users->name ?? '-' }}</td>
+            <td class="align-middle">{{ $auction?->buyer->legal_name ?? '-' }}</td>
+            <td class="align-middle">{{ $auction?->buyer->users->name ?? '-' }}</td>
             <td class="align-middle">{{ $auction_date ? date('d/m/Y', strtotime($auction_date)) : '-' }}</td>
             <td class="align-middle">
                 @if($auction_start && $auction_end)


### PR DESCRIPTION
## Summary
- prevent null reference errors when rfq auction relation missing
- safeguard product and buyer info access with nullsafe operator

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bdade867988327a68fd0c4b7d4cc86