### PR TITLE
Handle forcestop auction state in live RFQ metrics

### DIFF
--- a/app/Http/Controllers/Vendor/LiveAuctionRfqSinglePriceController.php
+++ b/app/Http/Controllers/Vendor/LiveAuctionRfqSinglePriceController.php
@@ -340,6 +340,7 @@ class LiveAuctionRfqSinglePriceController extends Controller
         if (!$auction) {
             return response()->json(['status' => false, 'message' => 'Auction not found'], 404);
         }
+        $isForcestop = (string)($auction->is_forcestop ?? '2');
 
         $hasAuctionIdCol = Schema::hasColumn('rfq_vendor_auction_price_total', 'rfq_auction_id');
 
@@ -360,7 +361,11 @@ class LiveAuctionRfqSinglePriceController extends Controller
         $rows = $rowsQuery->get();
 
         if ($rows->isEmpty()) {
-            return response()->json(['status' => true, 'data' => ['l1' => null, 'rank' => null, 'vendorPrice' => null]]);
+            return response()->json([
+                'status'       => true,
+                'is_forcestop' => $isForcestop,
+                'data'         => ['l1' => null, 'rank' => null, 'vendorPrice' => null],
+            ]);
         }
 
         $l1 = $rows->min('total_price');
@@ -382,8 +387,9 @@ class LiveAuctionRfqSinglePriceController extends Controller
         }
 
         return response()->json([
-            'status' => true,
-            'data' => [
+            'status'       => true,
+            'is_forcestop' => $isForcestop,
+            'data'         => [
                 'l1'          => $l1 !== null ? round((float) $l1, 2) : null,
                 'rank'        => $rank,
                 'vendorPrice' => $vendorPrice !== null ? round((float) $vendorPrice, 2) : null,

--- a/resources/views/vendor/live-auction/auction-rfq-reply-lot-wise.blade.php
+++ b/resources/views/vendor/live-auction/auction-rfq-reply-lot-wise.blade.php
@@ -837,6 +837,11 @@ $(function(){
             _token: '{{ csrf_token() }}',
             rfq_id: rfqId
         }).done(function(res){
+            if(res && res.status && res.is_forcestop === '1'){
+                alert("Auction has ended.");
+                setTimeout(function(){ window.location.reload(); }, 300);
+                return;
+            }
             if(res && res.status && res.data){
                 render(res.data);
             }

--- a/resources/views/vendor/live-auction/auction-rfq-reply.blade.php
+++ b/resources/views/vendor/live-auction/auction-rfq-reply.blade.php
@@ -928,6 +928,11 @@ $(function () {
             variant_ids: variantIds
         })
         .done(function (res) {
+            if (res && res.status && res.is_forcestop === '1') {
+                alert("Auction has ended.");
+                setTimeout(function(){ window.location.reload(); }, 300);
+                return;
+            }
             if (!res || !res.status || !res.data) return;
             $.each(res.data, function (vid, payload) {
                 updateOne(parseInt(vid, 10), payload || {});


### PR DESCRIPTION
## Summary
- surface `is_forcestop` flag in live RFQ metrics APIs
- alert vendors when forcestop is triggered during rank polling

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/rv22/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68bdb295b81c8327882b4180660ca375