### PR TITLE
Implement admin route permission middleware and gated sidebar

### DIFF
--- a/app/Http/Controllers/Admin/AccountController.php
+++ b/app/Http/Controllers/Admin/AccountController.php
@@ -11,8 +11,10 @@ use App\Models\UserPlan;
 use App\Models\User;
 use Carbon\Carbon;
 use PDF;
+use App\Traits\HasModulePermission;
 class AccountController extends Controller
-{
+{ 
+    use HasModulePermission;
     public function __construct()
     {
         if (auth()->check() && auth()->user()->user_type != 3) {
@@ -21,6 +23,8 @@ class AccountController extends Controller
     }
     public function vendor(Request $request)
     {
+        $this->ensurePermission('VENDORS_ACCOUNTS');
+
         $query = Vendor::with(['user','latestPlan']);
 
         if ($request->filled('vendor_name')) {
@@ -268,6 +272,8 @@ class AccountController extends Controller
     }
     public function buyer(Request $request)
     {
+        $this->ensurePermission('BUYERS_ACCOUNTS');
+
         $query = Buyer::with(['users','latestPlan']);
         if ($request->filled('buyer_name')) {
             $query->where('legal_name', 'like', '%' . $request->input('buyer_name') . '%');

--- a/app/Http/Controllers/Admin/AdvertisementController.php
+++ b/app/Http/Controllers/Admin/AdvertisementController.php
@@ -5,9 +5,11 @@ use App\Http\Controllers\Controller;
 use App\Models\Advertisement;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Http\Request;
+use App\Traits\HasModulePermission;
 
 class AdvertisementController extends Controller
 {
+    use HasModulePermission;
     public function __construct()
     {
         if (auth()->check() && auth()->user()->user_type != 3) {
@@ -16,6 +18,8 @@ class AdvertisementController extends Controller
     }
     public function index(Request $request)
     {
+        $this->ensurePermission('ADVERTISEMENT_AND_MARKETING');
+
         $query = Advertisement::query()->orderBy('id', 'desc');
 
         $perPage = $request->input('per_page', 25); // Default: 25 per page

--- a/app/Http/Controllers/Admin/AuctionRFQSummaryReportController.php
+++ b/app/Http/Controllers/Admin/AuctionRFQSummaryReportController.php
@@ -5,10 +5,14 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\RfqAuction;
+use App\Traits\HasModulePermission;
 class AuctionRFQSummaryReportController extends Controller
 {
+    use HasModulePermission;
     public function index(Request $request)
-    {   
+    {
+        $this->ensurePermission('VENDOR_REPORTS');
+
         $query=RfqAuction::with('rfq_vendor_auction.vendor','rfq_auction_variant','rfq_auction_variant.product','buyer');
         
         if ($request->filled('buyer_name'))

--- a/app/Http/Controllers/Admin/BulkApprovalProductsController.php
+++ b/app/Http/Controllers/Admin/BulkApprovalProductsController.php
@@ -10,14 +10,18 @@ use App\Models\VendorProduct;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Validator;
+use App\Traits\HasModulePermission;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Drivers\Gd\Driver;
 
 class BulkApprovalProductsController extends Controller
 {
-   
+    use HasModulePermission;
+
     public function index(Request $request)
     {
+        $this->ensurePermission('EDIT_PRODUCT');
+
         $subQuery = VendorProduct::select(DB::raw('MIN(id) as id'))
             ->where('edit_status',  '!=' ,2)
             ->where('approval_status', '!=', 1)

--- a/app/Http/Controllers/Admin/BuyerActivityReportController.php
+++ b/app/Http/Controllers/Admin/BuyerActivityReportController.php
@@ -5,10 +5,14 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Buyer;
+use App\Traits\HasModulePermission;
 
 class BuyerActivityReportController extends Controller
 {
+    use HasModulePermission;
     public function index(Request $request) {
+
+        $this->ensurePermission('BUYER_ACTIVITY_REPORTS');
 
         $query = Buyer::with(['users','latestPlan','latestPlan.plan','buyerUser','rfqs','orders']);
         $query->whereHas('users', function ($q) use ($request) {

--- a/app/Http/Controllers/Admin/BuyerController.php
+++ b/app/Http/Controllers/Admin/BuyerController.php
@@ -21,18 +21,22 @@ use App\Exports\BuyerExport;
 use Maatwebsite\Excel\Facades\Excel;
 use Illuminate\Support\Facades\DB;
 use App\Helpers\EmailHelper;
+use App\Traits\HasModulePermission;
 
 class BuyerController extends Controller
 {
+    use HasModulePermission;
     public function __construct()
     {
         if (auth()->check() && auth()->user()->user_type != 3) {
             abort(403, 'Unauthorized access.');
         }
-    } 
+    }
 
     public function index(Request $request)
-    {   
+    {
+        $this->ensurePermission('BUYER_MODULE');
+
         $currencies= Currency::all();
         $query = Buyer::with(['users']);
         if ($request->filled('user')) {

--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -10,9 +10,11 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
+use App\Traits\HasModulePermission;
 
 class CategoryController extends Controller
-{   
+{
+    use HasModulePermission;
     
     /**
      * Constructor to check user authorization.
@@ -32,7 +34,9 @@ class CategoryController extends Controller
      * @return \Illuminate\View\View|\Illuminate\Http\JsonResponse Returns a view with categories or JSON response for AJAX requests
      */
     public function index(Request $request, $id)
-    {   
+    {
+        $this->ensurePermission('PRODUCT_DIRECTORY');
+
         $query = Category::with('division');
 
         // If ID parameter is provided, filter by division_id

--- a/app/Http/Controllers/Admin/DivisionController.php
+++ b/app/Http/Controllers/Admin/DivisionController.php
@@ -10,9 +10,11 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
+use App\Traits\HasModulePermission;
 
 class DivisionController extends Controller
-{   
+{
+    use HasModulePermission;
 
     /**
      * Constructor to check user authorization.
@@ -32,6 +34,8 @@ class DivisionController extends Controller
      */
     public function index(Request $request)
     {
+        $this->ensurePermission('PRODUCT_DIRECTORY');
+
         $query = Division::query();
 
         if ($request->division_name) {

--- a/app/Http/Controllers/Admin/EditProductRequestController.php
+++ b/app/Http/Controllers/Admin/EditProductRequestController.php
@@ -8,13 +8,17 @@ use App\Models\VendorProduct;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Validator;
+use App\Traits\HasModulePermission;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Drivers\Gd\Driver;
 
 class EditProductRequestController extends Controller
 {
+    use HasModulePermission;
     public function index(Request $request)
     {
+        $this->ensurePermission('EDIT_PRODUCT');
+
         $query = VendorProduct::with(['vendor', 'product', 'receivedfrom'])
             ->where('edit_status', 1) // 1 => Edit Request
             ->where('approval_status', '!=', 1)

--- a/app/Http/Controllers/Admin/ExportVerifiedProductController.php
+++ b/app/Http/Controllers/Admin/ExportVerifiedProductController.php
@@ -8,11 +8,15 @@ use App\Models\ExportJob;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use App\Traits\HasModulePermission;
 
 class ExportVerifiedProductController extends Controller
 {
+    use HasModulePermission;
     public function index()
     {
+        $this->ensurePermission('ALL_VERIFIED_PRODUCTS');
+
         $exports = ExportJob::orderBy('created_at', 'desc')->paginate(1000);
         return view('admin.verified-products.export', compact('exports'));
     }

--- a/app/Http/Controllers/Admin/ForwardAuctionSummaryReportController.php
+++ b/app/Http/Controllers/Admin/ForwardAuctionSummaryReportController.php
@@ -5,9 +5,11 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use App\Traits\HasModulePermission;
 
 class ForwardAuctionSummaryReportController extends Controller
 {
+    use HasModulePermission;
     protected function baseQuery(Request $request)
     {
         $query = DB::table('forward_auctions as fa')
@@ -47,6 +49,8 @@ class ForwardAuctionSummaryReportController extends Controller
 
     public function index(Request $request)
     {
+        $this->ensurePermission('VENDOR_REPORTS');
+
         $query = $this->baseQuery($request);
         $perPage = $request->input('per_page', 25);
         $results = $query->paginate($perPage)->appends($request->all());

--- a/app/Http/Controllers/Admin/HelpSupportController.php
+++ b/app/Http/Controllers/Admin/HelpSupportController.php
@@ -4,9 +4,13 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\HelpSupport;
 use App\Models\User;
+use App\Traits\HasModulePermission;
 class HelpSupportController extends Controller
 {
+    use HasModulePermission;
     public function index(Request $request){
+        $this->ensurePermission('HELP_AND_SUPPORT');
+
         $query = HelpSupport::with('venderBuyer')->where('id', '>', '0');
 
         if ($request->filled('legal_name'))

--- a/app/Http/Controllers/Admin/NewProductRequestController.php
+++ b/app/Http/Controllers/Admin/NewProductRequestController.php
@@ -10,13 +10,17 @@ use App\Models\VendorProduct;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Validator;
+use App\Traits\HasModulePermission;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Drivers\Gd\Driver;
 
 class NewProductRequestController extends Controller
 {
+    use HasModulePermission;
     public function index(Request $request)
     {
+        $this->ensurePermission('NEW_PRODUCT_REQUEST');
+
         $query = VendorProduct::with(['vendor','receivedfrom'])
             ->where('edit_status', 2) // 1 => New Request
             ->where('approval_status', '!=', 1)

--- a/app/Http/Controllers/Admin/NotificationController.php
+++ b/app/Http/Controllers/Admin/NotificationController.php
@@ -5,8 +5,10 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Notification;
+use App\Traits\HasModulePermission;
 class NotificationController extends Controller
 {
+    use HasModulePermission;
      /**
      * Constructor to check user authorization.
      */
@@ -18,6 +20,8 @@ class NotificationController extends Controller
     }
 
     public function index(Request $request) {
+        $this->ensurePermission('INTERNAL');
+
         $query = Notification::with(['users', 'senders']);
 
         if ($request->filled('user')) {

--- a/app/Http/Controllers/Admin/PlanController.php
+++ b/app/Http/Controllers/Admin/PlanController.php
@@ -5,18 +5,22 @@ use App\Http\Controllers\Controller;
 use App\Models\Plan;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Http\Request;
+use App\Traits\HasModulePermission;
 
 class PlanController extends Controller
 {
+    use HasModulePermission;
     public function __construct()
     {
         if (auth()->check() && auth()->user()->user_type != 3) {
             abort(403, 'Unauthorized access.');
         }
     }
-    
+
     public function index(Request $request)
     {
+        $this->ensurePermission('PLAN_MODULE');
+
         $query = Plan::query()->orderBy('id', 'desc');
 
         $perPage = $request->input('per_page', 25); // Default: 25 per page

--- a/app/Http/Controllers/Admin/ProductApprovalController.php
+++ b/app/Http/Controllers/Admin/ProductApprovalController.php
@@ -9,13 +9,17 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
+use App\Traits\HasModulePermission;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Drivers\Gd\Driver as GdDriver;
 
 class ProductApprovalController extends Controller
 {
+    use HasModulePermission;
     public function index(Request $request)
     {
+        $this->ensurePermission('PRODUCTS_FOR_APPROVAL');
+
         $query = VendorProduct::with(['vendor', 'product' , 'receivedfrom'])
             ->where('edit_status', 3)
             ->where('approval_status', '!=', 1)

--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -11,9 +11,11 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
+use App\Traits\HasModulePermission;
 
 class ProductController extends Controller
-{   
+{
+    use HasModulePermission;
     
     /**
      * Constructor to check user authorization.
@@ -34,6 +36,8 @@ class ProductController extends Controller
      */
     public function index(Request $request, $id = null)
     {
+        $this->ensurePermission('PRODUCT_DIRECTORY');
+
         $query = Product::with(['division', 'category']);
 
         if ($id) {

--- a/app/Http/Controllers/Admin/ProductsCategoryDivisionReportController.php
+++ b/app/Http/Controllers/Admin/ProductsCategoryDivisionReportController.php
@@ -5,9 +5,13 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\Product;
+use App\Traits\HasModulePermission;
 class ProductsCategoryDivisionReportController extends Controller
 {
+    use HasModulePermission;
     public function index(Request $request) {
+
+        $this->ensurePermission('DIVISION_AND_CATEGORY_WISE');
 
         $query = $this->querires($request);
         $results = $query->orderBy('product_name')->paginate(25);

--- a/app/Http/Controllers/Admin/RFQSummaryReportController.php
+++ b/app/Http/Controllers/Admin/RFQSummaryReportController.php
@@ -11,12 +11,17 @@ use App\Models\RfqProductVariant;
 use App\Models\RfqVendorQuotation;
 use App\Models\Order;
 use Illuminate\Support\Facades\DB;
+use App\Traits\HasModulePermission;
 
 class RFQSummaryReportController extends Controller
 {
 
+    use HasModulePermission;
+
     public function index(Request $request)
     {
+        $this->ensurePermission('BUYER_REPORTS');
+
         $perPage = $request->input('per_page', 25);
 
         // 1. Build the base query with necessary joins

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -14,11 +14,13 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
 use Maatwebsite\Excel\Facades\Excel;
 use App\Exports\UsersExport;
+use App\Traits\HasModulePermission;
 
 
 class UserController extends Controller
-{   
-    
+{
+    use HasModulePermission;
+
     /**
      * Constructor to check user authorization.
      */
@@ -37,6 +39,8 @@ class UserController extends Controller
      */
     public function index(Request $request)
     {
+        $this->ensurePermission('ADMIN_USERS');
+
         // Initialize the query with eager loading of 'role'
         $query = User::with('role')
                     ->where('user_type', 3)

--- a/app/Http/Controllers/Admin/UserRoleController.php
+++ b/app/Http/Controllers/Admin/UserRoleController.php
@@ -10,10 +10,12 @@ use App\Models\UserRoleModulePermission;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\DB;
+use App\Traits\HasModulePermission;
 
 
 class UserRoleController extends Controller
-{   
+{
+    use HasModulePermission;
 
     /**
      * Constructor to check user authorization.
@@ -32,6 +34,8 @@ class UserRoleController extends Controller
      */
     public function index()
     {
+        $this->ensurePermission('MANAGE_ROLE');
+
         $roles = UserRole::where('role_name_for', 3)->paginate(25);
         return view('admin.user-roles.index', compact('roles'));
     }

--- a/app/Http/Controllers/Admin/VendorActivityReportController.php
+++ b/app/Http/Controllers/Admin/VendorActivityReportController.php
@@ -12,14 +12,18 @@ use App\Models\RfqVendorQuotation;
 use App\Models\Order;
 use App\Models\VendorProduct;
 use Illuminate\Support\Facades\DB;
+use App\Traits\HasModulePermission;
 
 class VendorActivityReportController extends Controller
 {
+    use HasModulePermission;
     /**
      * Display the vendor activity report with filters and statistics.
      */
     public function index(Request $request)
     {
+        $this->ensurePermission('VENDOR_ACTIVITY_REPORTS');
+
         $perPage = $request->input('per_page', 25); // Pagination size
 
         /**

--- a/app/Http/Controllers/Admin/VendorController.php
+++ b/app/Http/Controllers/Admin/VendorController.php
@@ -17,12 +17,14 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\DB;
 use App\Helpers\EmailHelper;
+use App\Traits\HasModulePermission;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 
 class VendorController extends Controller
 {
+    use HasModulePermission;
     public $vendor_profile_dir = 'vendor-profile';
 
     public function __construct()
@@ -32,7 +34,9 @@ class VendorController extends Controller
         }
     }
     public function index(Request $request){
-        
+
+        $this->ensurePermission('VENDOR_MODULE');
+
         $query = Vendor::with(['user'])->withCount(['vendor_products as vendor_products_count' => function ($query) {
             $query->where('approval_status', 1)
                   ->where('edit_status', 0);

--- a/app/Http/Controllers/Admin/VendorDisabledProductReportController.php
+++ b/app/Http/Controllers/Admin/VendorDisabledProductReportController.php
@@ -8,14 +8,18 @@ use Illuminate\Support\Facades\File;
 use App\Models\VendorProduct;
 use App\Models\ProductAlias;
 use App\Models\RfqProduct; // Model for rfq_products
+use App\Traits\HasModulePermission;
 
 class VendorDisabledProductReportController extends Controller
 {
+    use HasModulePermission;
     /**
      * Display a listing of the disabled products report.
      */
     public function index(Request $request)
     {
+        $this->ensurePermission('VENDOR_REPORTS');
+
         $query = VendorProduct::where('vendor_status', 2); //  2 = disabled
 
         // Optional filters

--- a/app/Http/Controllers/Admin/VerifiedProductController.php
+++ b/app/Http/Controllers/Admin/VerifiedProductController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
+use App\Traits\HasModulePermission;
 use Intervention\Image\ImageManager;
 use Intervention\Image\Drivers\Gd\Driver as GdDriver;
 use App\Exports\VerifiedProductsExport;
@@ -32,7 +33,8 @@ use Illuminate\Support\Str;
  * - Managing product tags/badges
  */
 class VerifiedProductController extends Controller
-{   
+{
+    use HasModulePermission;
 
     /**
      * Display a paginated list of verified products with filtering capabilities
@@ -41,8 +43,10 @@ class VerifiedProductController extends Controller
      * @return \Illuminate\View\View|\Illuminate\Http\Response Returns view for HTML or partial table for AJAX
      */
     public function index(Request $request)
-    {   
-        // slected column  
+    {
+        $this->ensurePermission('ALL_VERIFIED_PRODUCTS');
+
+        // slected column
         $query = VendorProduct::with(['vendor', 'product'])->where('approval_status', 1)->orderBy('updated_at', 'desc'); // Order by updated_at in descending order
         if ($request->filled('product_name')) {
             $query->whereHas('product', function ($q) use ($request) {

--- a/app/Http/Middleware/EnsurePermission.php
+++ b/app/Http/Middleware/EnsurePermission.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class EnsurePermission
+{
+    /**
+     * Map route prefixes to module slugs.
+     *
+     * @var array<string,string>
+     */
+    protected array $moduleMap = [
+        'divisions' => 'PRODUCT_DIRECTORY',
+        'verified-products' => 'ALL_VERIFIED_PRODUCTS',
+        'product-approvals' => 'PRODUCTS_FOR_APPROVAL',
+        'new-products' => 'NEW_PRODUCT_REQUEST',
+        'edit-products' => 'EDIT_PRODUCT',
+        'bulk-products' => 'EDIT_PRODUCT',
+        'buyer' => 'BUYER_MODULE',
+        'vendor' => 'VENDOR_MODULE',
+        'advertisement' => 'ADVERTISEMENT_AND_MARKETING',
+        'accounts.buyer' => 'BUYERS_ACCOUNTS',
+        'accounts.vendor' => 'VENDORS_ACCOUNTS',
+        'plan' => 'PLAN_MODULE',
+        'reports.product-division-category' => 'DIVISION_AND_CATEGORY_WISE',
+        'reports.buyer-activity' => 'BUYER_ACTIVITY_REPORTS',
+        'vendor-activity-report' => 'VENDOR_ACTIVITY_REPORTS',
+        'users' => 'ADMIN_USERS',
+        'user-roles' => 'MANAGE_ROLE',
+        'help_support' => 'HELP_AND_SUPPORT',
+        'password' => 'CHANGE_PASSWORD',
+    ];
+
+    /**
+     * Map route action to permission type.
+     *
+     * @var array<string,string>
+     */
+    protected array $permissionMap = [
+        'index' => 'view',
+        'show' => 'view',
+        'create' => 'add',
+        'store' => 'add',
+        'edit' => 'edit',
+        'update' => 'edit',
+        'destroy' => 'delete',
+        'delete' => 'delete',
+        'bulkDelete' => 'delete',
+    ];
+
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $route = $request->route();
+        $name = $route?->getName();
+
+        if ($name) {
+            $moduleSlug = $this->resolveModuleSlug($name);
+            if ($moduleSlug) {
+                $action = $this->resolveAction($name);
+                $permissionType = $this->permissionMap[$action] ?? 'view';
+
+                if (!checkPermission($moduleSlug, $permissionType, '3')) {
+                    abort(403, 'Unauthorized');
+                }
+            }
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Resolve module slug based on route name.
+     */
+    protected function resolveModuleSlug(string $routeName): ?string
+    {
+        foreach ($this->moduleMap as $prefix => $slug) {
+            if (Str::startsWith($routeName, 'admin.' . $prefix)) {
+                return $slug;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Resolve the action segment from the route name.
+     */
+    protected function resolveAction(string $routeName): string
+    {
+        $parts = explode('.', $routeName);
+        return end($parts);
+    }
+}

--- a/app/Traits/HasModulePermission.php
+++ b/app/Traits/HasModulePermission.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Traits;
+
+trait HasModulePermission
+{
+    protected function ensurePermission(string $moduleSlug, string $permissionType = 'view', string $moduleFor = '3'): void
+    {
+        if (!checkPermission($moduleSlug, $permissionType, $moduleFor)) {
+            abort(403, 'Unauthorized');
+        }
+    }
+}
+

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -17,6 +17,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'validate_account' => \App\Http\Middleware\ValidateAccount::class,
             'usertype' => \App\Http\Middleware\UserTypeMiddleware::class,
             'profile_verified' => \App\Http\Middleware\ProfileVerified::class,
+            'permission' => \App\Http\Middleware\EnsurePermission::class,
         ])->validateCsrfTokens(except: [
             'buyer/ajax/*',
         ]);

--- a/resources/views/admin/layouts/sidebar.blade.php
+++ b/resources/views/admin/layouts/sidebar.blade.php
@@ -8,12 +8,21 @@
                                 <span class="nav_text">Dashboard</span></a>
                         </div>
 
+                        @if(checkPermission('PRODUCT_DIRECTORY','view','3'))
                         <div>
                             <a href="{{ route('admin.divisions.index') }}" class="menu-text-colour submenu-list">
                                 <span class="sidebar-icon"><i class="bi bi-speedometer2 sidebar-bi"></i></span>
                                 <span class="nav_text">Product Directory</span></a>
                         </div>
+                        @endif
 
+                        @php
+                            $manageProducts = checkPermission('ALL_VERIFIED_PRODUCTS','view','3') ||
+                                              checkPermission('PRODUCTS_FOR_APPROVAL','view','3') ||
+                                              checkPermission('NEW_PRODUCT_REQUEST','view','3') ||
+                                              checkPermission('EDIT_PRODUCT','view','3');
+                        @endphp
+                        @if($manageProducts)
                         <div class="accordion-item">
                             <h2 class="accordion-header" id="headingOne">
                                 <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
@@ -26,38 +35,60 @@
                                 data-bs-parent="#sidebarAccordion">
                                 <div class="accordion-body">
                                     <ul class="accordian-submenu">
+                                        @if(checkPermission('ALL_VERIFIED_PRODUCTS','view','3'))
                                         <li><a href="{{ route('admin.verified-products.index') }}">All Verified
                                                 Products</a></li>
+                                        @endif
+                                        @if(checkPermission('PRODUCTS_FOR_APPROVAL','view','3'))
                                         <li><a href="{{ route('admin.product-approvals.index') }}">Products for
                                                 Approval</a></li>
+                                        @endif
+                                        @if(checkPermission('NEW_PRODUCT_REQUEST','view','3'))
                                         <li><a href="{{ route('admin.new-products.index') }}">New Product Request</a>
                                         </li>
+                                        @endif
+                                        @if(checkPermission('EDIT_PRODUCT','view','3'))
                                         <li><a href="{{ route('admin.edit-products.index') }}">Edit Product</a></li>
+                                        @endif
+                                        @if(checkPermission('EDIT_PRODUCT','view','3'))
                                         <li><a href="{{ route('admin.bulk-products.index') }}">Products for Approval
                                                 Bulk</a></li>
+                                        @endif
                                     </ul>
                                 </div>
                             </div>
                         </div>
+                        @endif
 
+                        @if(checkPermission('BUYER_MODULE','view','3'))
                         <div>
                             <a href="{{ route('admin.buyer.index') }}" class="menu-text-colour submenu-list">
                                 <span class="sidebar-icon"><i class="bi bi-bag sidebar-bi"></i></span>
                                 <span class="nav_text">Buyer Module</span></a>
                         </div>
+                        @endif
 
+                        @if(checkPermission('VENDOR_MODULE','view','3'))
                         <div>
                             <a href="{{ route('admin.vendor.index') }}" class="menu-text-colour submenu-list">
                                 <span class="sidebar-icon"><i class="bi bi-shop-window sidebar-bi"></i></span>
                                 <span class="nav_text"> Vendor Module</span></a>
                         </div>
+                        @endif
 
+                        @if(checkPermission('ADVERTISEMENT_AND_MARKETING','view','3'))
                         <div>
                             <a href="{{ route('admin.advertisement.index') }}" class="menu-text-colour submenu-list">
                                 <span class="sidebar-icon"><i class="bi bi-megaphone sidebar-bi"></i></span>
                                 <span class="nav_text">Advertisement/Marketing</span>
                             </a>
                         </div>
+                        @endif
+                        @php
+                            $accountsModule = checkPermission('BUYERS_ACCOUNTS','view','3') ||
+                                              checkPermission('VENDORS_ACCOUNTS','view','3');
+                        @endphp
+                        @if($accountsModule)
                         <div class="accordion-item">
                             <h2 class="accordion-header" id="headingFive">
                                 <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
@@ -70,17 +101,32 @@
                                 data-bs-parent="#sidebarAccordion">
                                 <div class="accordion-body">
                                     <ul class="accordian-submenu">
+                                        @if(checkPermission('BUYERS_ACCOUNTS','view','3'))
                                         <li><a href="{{ route('admin.accounts.buyer') }}">Buyer's Accounts</a></li>
+                                        @endif
+                                        @if(checkPermission('VENDORS_ACCOUNTS','view','3'))
                                         <li><a href="{{ route('admin.accounts.vendor') }}">Vendor's Accounts</a></li>
+                                        @endif
                                     </ul>
                                 </div>
                             </div>
                         </div>
+                        @endif
+                        @if(checkPermission('PLAN_MODULE','view','3'))
                         <div>
                             <a href="{{ route('admin.plan.index') }}" class="menu-text-colour submenu-list">
                                 <span class="sidebar-icon"><i class="bi bi-columns sidebar-bi"></i></span>
                                 <span class="nav_text">Plan Module </span></a>
                         </div>
+                        @endif
+                        @php
+                            $reportsModule = checkPermission('DIVISION_AND_CATEGORY_WISE','view','3') ||
+                                             checkPermission('BUYER_ACTIVITY_REPORTS','view','3') ||
+                                             checkPermission('VENDOR_ACTIVITY_REPORTS','view','3') ||
+                                             checkPermission('BUYER_REPORTS','view','3') ||
+                                             checkPermission('VENDOR_REPORTS','view','3');
+                        @endphp
+                        @if($reportsModule)
                         <div class="accordion-item">
                             <h2 class="accordion-header" id="headingThree">
                                 <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
@@ -94,23 +140,38 @@
                                 <div class="accordion-body">
                                     <ul class="accordian-submenu" aria-labelledby="headingThree"
                                         data-bs-parent="#sidebarAccordion">
+                                        @if(checkPermission('DIVISION_AND_CATEGORY_WISE','view','3'))
                                         <li><a href="{{route('admin.reports.product-division-category')}}">Products
                                                 Division & Category Wise</a></li>
+                                        @endif
+                                        @if(checkPermission('BUYER_ACTIVITY_REPORTS','view','3'))
                                         <li><a href="{{route('admin.reports.buyer-activity')}}">Buyer Activity
                                                 Reports</a></li>
+                                        @endif
+                                        @if(checkPermission('VENDOR_ACTIVITY_REPORTS','view','3'))
                                         <li><a href="{{ route('admin.vendor-activity-report.index') }}">Vendor Activity
                                                 Reports</a></li>
+                                        @endif
+                    @if(checkPermission('VENDOR_REPORTS','view','3'))
                                         <li><a href="{{ route('admin.vendor-disabled-product-report.index') }}">Vendor
                                                 Disabled Products</a></li>
+                                        @endif
+                                        @if(checkPermission('BUYER_REPORTS','view','3'))
                                         <li><a href="{{ route('admin.rfq-summary-report.index') }}">RFQs Summary</a>
                                         </li>
                                         <li><a href="{{ route('admin.reports.auction-rfqs-summary') }}">Auction RFQs
                                                 Summary</a></li>
                                         <li><a href="{{ route('admin.reports.forward-auctions-summary') }}">Forward Auction Reports</a></li>
+                                        @endif
                                     </ul>
                                 </div>
                             </div>
                         </div>
+                        @endif
+                        @php
+                            $userMgmt = checkPermission('ADMIN_USERS','view','3') || checkPermission('MANAGE_ROLE','view','3');
+                        @endphp
+                        @if($userMgmt)
                         <div class="accordion-item">
                             <h2 class="accordion-header" id="headingTwo">
                                 <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
@@ -124,23 +185,32 @@
                                 <div class="accordion-body">
                                     <ul class="accordian-submenu" aria-labelledby="headingTwo"
                                         data-bs-parent="#sidebarAccordion">
+                                        @if(checkPermission('ADMIN_USERS','view','3'))
                                         <li><a href="{{ route('admin.users.index') }}">Admin User</a></li>
+                                        @endif
+                                        @if(checkPermission('MANAGE_ROLE','view','3'))
                                         <li><a href="{{ route('admin.user-roles.index') }}">Manage role</a></li>
+                                        @endif
                                     </ul>
                                 </div>
                             </div>
                         </div>
+                        @endif
+                        @if(checkPermission('HELP_AND_SUPPORT','view','3'))
                         <div>
                             <a href="{{ route('admin.help_support.index') }}" class="menu-text-colour submenu-list">
                                 <span class="sidebar-icon"><i class="bi bi-question-circle sidebar-bi"></i></span>
                                 <span class="nav_text"> Help and Support</span>
                             </a>
                         </div>
+                        @endif
+                        @if(checkPermission('CHANGE_PASSWORD','view','3'))
                         <div>
                             <a href="{{ route('admin.password.change') }}" class="menu-text-colour submenu-list">
                                 <span class="sidebar-icon"><i class="bi bi-lock"></i></span>
                                 <span class="nav_text">Change Password </span></a>
                         </div>
+                        @endif
 
                         <div class="accordion-item">
                             <h2 class="accordion-header" id="headingFour">
@@ -160,12 +230,14 @@
                                 </div>
                             </div>
                         </div>
+                        @if(checkPermission('BUYER_QUERY','view','3'))
                         <div>
                             <a href="#" class="menu-text-colour submenu-list">
                                 <span class="sidebar-icon"><i class="bi bi-info-circle sidebar-bi"></i></span>
                                 <span class="nav_text"> Buyer Query</span>
                             </a>
                         </div>
+                        @endif
                     </div>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -101,7 +101,7 @@ Route::group(['prefix' => 'super-admin'], function () {
     Route::post('/reset-password', [AdminLoginController::class, 'resetPasswordSubmit'])->name('admin.reset-password.submit');
 
 
-    Route::middleware(['auth', 'usertype:3'])->group(function () {
+    Route::middleware(['auth', 'usertype:3', 'permission'])->group(function () {
         Route::get('/dashboard', function () {
             return view('admin.admin-dashboard');
         })->name('admin.dashboard');


### PR DESCRIPTION
## Summary
- add EnsurePermission middleware to map route names to module permissions
- register permission middleware and enforce on super-admin routes
- gate admin sidebar entries based on role permissions
- centralize controller permission checks via HasModulePermission trait and guard listing actions

## Testing
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: require(/workspace/rv22/vendor/autoload.php): Failed to open stream: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68be7594aed083279d6d9cc0a3e02181