### PR TITLE
Hide Add buttons without permission in admin

### DIFF
--- a/resources/views/admin/advertisement/index.blade.php
+++ b/resources/views/admin/advertisement/index.blade.php
@@ -19,9 +19,11 @@
                 <div class="col-md-12 botom-border">
                     <div class="d-flex justify-content-between align-items-center mb-3">
                         <h1>Manage Advertisements</h1>
+                        @if(checkPermission('ADVERTISEMENT_AND_MARKETING','add','3'))
                         <a href="{{ route('admin.advertisement.create') }}" class="btn-rfq btn-rfq-white">
-                            <i class="bi bi-plus"></i> Add 
+                            <i class="bi bi-plus"></i> Add
                         </a>
+                        @endif
                     </div>
            
                     <div id="table-container">

--- a/resources/views/admin/advertisement/index_old.blade.php
+++ b/resources/views/admin/advertisement/index_old.blade.php
@@ -7,7 +7,9 @@
     <div class="card shadow mb-4 mt-4">
         <div class="card-header py-3 d-flex justify-content-between align-items-center">
             <h6 class="m-0 font-weight-bold text-primary">Manage Advertisement</h6>
+            @if(checkPermission('ADVERTISEMENT_AND_MARKETING','add','3'))
             <a href="{{ route('admin.advertisement.create') }}" class="btn btn-primary">Add New</a>
+            @endif
         </div>
         <div class="card-body">
             <div class="table-responsive">

--- a/resources/views/admin/categories/index.blade.php
+++ b/resources/views/admin/categories/index.blade.php
@@ -55,9 +55,11 @@
                                             <i class="bi bi-search"></i> Search
                                         </button>
                                         <a href="{{ route('admin.categories.index', ['id' => $id]) }}" class="btn-style btn-style-danger mx-2">RESET</a>
+                                        @if(checkPermission('PRODUCT_DIRECTORY','add','3'))
                                         <a href="{{ route('admin.categories.create', ['id' => $id]) }}" class="btn-style btn-style-white">
                                             <i class="bi bi-plus-square d-none d-sm-inline-block"></i> CATEGORY
                                         </a>
+                                        @endif
                                     </li>
                                 </ul>
                             </div>

--- a/resources/views/admin/divisions/index.blade.php
+++ b/resources/views/admin/divisions/index.blade.php
@@ -55,9 +55,11 @@
                                     <li class="notShow_on_mobile">
                                         <a href="{{ route('admin.divisions.index') }}" class="btn-style btn-style-danger">RESET</a>
                                     </li>
+                                    @if(checkPermission('PRODUCT_DIRECTORY','add','3'))
                                     <li class="notShow_on_mobile">
                                         <a href="{{ route('admin.divisions.create') }}" class="btn-style btn-style-white"><i class="bi bi-plus-square"></i> ADD DIVISION</a>
                                     </li>
+                                    @endif
                                 </ul>
                                 <ul class="rapo_btn-grp">
                                     <li>
@@ -66,9 +68,11 @@
                                     <li>
                                         <a href="{{ route('admin.divisions.index') }}" class="btn-style btn-style-danger">RESET</a>
                                     </li>
+                                    @if(checkPermission('PRODUCT_DIRECTORY','add','3'))
                                     <li>
                                         <a href="{{ route('admin.divisions.create') }}" class="btn-style btn-style-white"><i class="bi bi-plus-square d-none d-sm-block"></i> ADD DIVISION</a>
                                     </li>
+                                    @endif
                                 </ul>
                             </div>
                         </div>

--- a/resources/views/admin/plan/index.blade.php
+++ b/resources/views/admin/plan/index.blade.php
@@ -25,9 +25,11 @@
                     <div class="card-body">
                         <div class="d-flex justify-content-between align-items-center mb-3">
                             <h1 class="mb-0">Plan Module List</h1>
+                            @if(checkPermission('PLAN_MODULE','add','3'))
                             <a href="{{ route('admin.plan.create') }}" class="btn-rfq btn-rfq-primary btn-sm">
                                 <i class="fas fa-plus me-1"></i> Add
                             </a>
+                            @endif
                         </div>
                         <div id="table-container">
                           @include('admin.plan.partials.table', ['plans' => $plans])

--- a/resources/views/admin/plan/index_OLD.blade.php
+++ b/resources/views/admin/plan/index_OLD.blade.php
@@ -7,7 +7,9 @@
     <div class="card shadow mb-4 mt-4">
         <div class="card-header py-3 d-flex justify-content-between align-items-center">
             <h6 class="m-0 font-weight-bold text-primary">Manage Plan</h6>
+            @if(checkPermission('PLAN_MODULE','add','3'))
             <a href="{{ route('admin.plan.create') }}" class="btn btn-primary">Add New</a>
+            @endif
         </div>
         <div class="card-body">
             <div class="table-responsive">

--- a/resources/views/admin/products/index.blade.php
+++ b/resources/views/admin/products/index.blade.php
@@ -60,19 +60,23 @@
                                     <li class="notShow_on_mobile">
                                         <a href="{{ route('admin.products.index', ['id' => $id]) }}" class="btn-style btn-style-danger">RESET</a>
                                     </li>
+                                    @if(checkPermission('PRODUCT_DIRECTORY','add','3'))
                                     <li class="notShow_on_mobile">
                                         <a href="{{ route('admin.products.create', ['id' => $id]) }}" class="btn-style btn-style-white">
                                             <i class="bi bi-plus-square"></i> PRODUCT
                                         </a>
                                     </li>
+                                    @endif
                                     <li class="d-md-none">
                                         <button type="submit" class="btn-style btn-style-primary">
                                             <i class="bi bi-search"></i> Search
                                         </button>
                                         <a href="{{ route('admin.products.index', ['id' => $id]) }}" class="btn-style btn-style-danger mx-2">RESET</a>
+                                        @if(checkPermission('PRODUCT_DIRECTORY','add','3'))
                                         <a href="{{ route('admin.products.create', ['id' => $id]) }}" class="btn-style btn-style-white">
                                             <i class="bi bi-plus-square"></i> PRODUCT
                                         </a>
+                                        @endif
                                     </li>
                                 </ul>
                             </div>

--- a/resources/views/admin/user-roles/index.blade.php
+++ b/resources/views/admin/user-roles/index.blade.php
@@ -26,9 +26,11 @@
                     <div class="card-body">
                         <div class="d-flex justify-content-between align-items-center mb-3">
                             <h1 class="mb-0">User Roles</h1>
+                            @if(checkPermission('MANAGE_ROLE','add','3'))
                             <a href="{{ route('admin.user-roles.create') }}" class="btn-rfq btn-rfq-primary btn-sm">
                                 <i class="fas fa-plus me-1"></i> Add New Role
                             </a>
+                            @endif
                         </div>
                         <div class="table-responsive">
                             <table class="product_listing_table">

--- a/resources/views/admin/user-roles/index_old.blade.php
+++ b/resources/views/admin/user-roles/index_old.blade.php
@@ -27,9 +27,11 @@
     <div class="card mt-4">
         <div class="card-header d-flex justify-content-between align-items-center">
             <h4 class="mb-0">User Roles</h4>
+            @if(checkPermission('MANAGE_ROLE','add','3'))
             <a href="{{ route('admin.user-roles.create') }}" class="btn btn-primary btn-sm">
                 <i class="fas fa-plus me-1"></i> Add New Role
             </a>
+            @endif
         </div>
         <div class="card-body">
             <div class="table-responsive">

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -83,11 +83,13 @@
                                             class="btn-style btn-style-danger">RESET</a>
                                             
                                     </div>
+                                    @if(checkPermission('ADMIN_USERS','add','3'))
                                     <div class="col-auto">
-                                    <a href="{{ route('admin.users.create') }}" class="btn-rfq btn-rfq-white ">
-                                            <i class="bi bi-plus"></i> ADD 
+                                        <a href="{{ route('admin.users.create') }}" class="btn-rfq btn-rfq-white ">
+                                            <i class="bi bi-plus"></i> ADD
                                         </a>
                                     </div>
+                                    @endif
                                 </div>
                             </form>
 

--- a/resources/views/admin/users/index_old.blade.php
+++ b/resources/views/admin/users/index_old.blade.php
@@ -24,7 +24,9 @@
     <div class="card shadow mb-4 mt-4">
         <div class="card-header py-3 d-flex justify-content-between align-items-center">
             <h6 class="m-0 font-weight-bold text-primary">User Management</h6>
+            @if(checkPermission('ADMIN_USERS','add','3'))
             <a href="{{ route('admin.users.create') }}" class="btn btn-primary">Add New User</a>
+            @endif
         </div>
         <div class="card-body">
             <!-- Search Filter Section -->

--- a/resources/views/admin/vendor/index.blade.php
+++ b/resources/views/admin/vendor/index.blade.php
@@ -112,10 +112,12 @@
                                             EXPORT
                                         </button>
                                     </div>
+                                    @if(checkPermission('VENDOR_MODULE','add','3'))
                                     <div class="col-auto mt-3 mt-sm-4">
                                         <a href="{{ route('admin.vendor.registration') }}"
                                             class="btn-rfq btn-rfq-white"> + Add New Vendor</a>
                                     </div>
+                                    @endif
                                 </div>
                                 {{-- <ul class="rfq-filter-button">
                                     <li>

--- a/resources/views/admin/vendor/partials/table.blade.php
+++ b/resources/views/admin/vendor/partials/table.blade.php
@@ -45,9 +45,11 @@
                 <td>{{ $result->vendor_products_count ?? ''}}</td>
                 <td>{{ !empty($result->user->country_code) ? '+'.$result->user->country_code : '' }} {{ $result->user->mobile ?? ''}}</td>
                 <td>
-                    @if(!empty($result->vendor_code) && $result->user->status == 1)
-                    <a href="{{ route('admin.vendor.products.create', $result->user_id) }}" class="btn-rfq btn-rfq-secondary btn-sm vendor-product-btn" style="padding: 1px 8px;">+PRD</a>
-            	    <a href="{{ route('admin.vendor.products.bulk_create', $result->user_id) }}" class="btn-rfq btn-rfq-secondary btn-sm vendor-product-btn" style="padding: 1px 8px;">++PRD</a>
+                    @if(checkPermission('VENDOR_MODULE','add','3'))
+                        @if(!empty($result->vendor_code) && $result->user->status == 1)
+                        <a href="{{ route('admin.vendor.products.create', $result->user_id) }}" class="btn-rfq btn-rfq-secondary btn-sm vendor-product-btn" style="padding: 1px 8px;">+PRD</a>
+                        <a href="{{ route('admin.vendor.products.bulk_create', $result->user_id) }}" class="btn-rfq btn-rfq-secondary btn-sm vendor-product-btn" style="padding: 1px 8px;">++PRD</a>
+                        @endif
                     @endif
                 </td>
                 <td>


### PR DESCRIPTION
## Summary
- Hide Add buttons in admin views unless user has "add" permission for respective module
- Applied checks across divisions, users, roles, products, advertisements, categories, plans, and vendor modules

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/rv22/vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading packages.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be86c8ecd48327b555669441e006b1