### PR TITLE
Guard admin edit buttons with permission checks

### DIFF
--- a/resources/views/admin/categories/partials/table.blade.php
+++ b/resources/views/admin/categories/partials/table.blade.php
@@ -28,7 +28,9 @@
                     </span>
                 </td>
                 <td>
-                    <a href="{{ route('admin.categories.edit', $category->id) }}" class="btn-rfq btn-sm btn-rfq-secondary edit_page mr-1">Edit</a>
+                    @if(checkPermission('PRODUCT_DIRECTORY','edit','3'))
+                        <a href="{{ route('admin.categories.edit', $category->id) }}" class="btn-rfq btn-sm btn-rfq-secondary edit_page mr-1">Edit</a>
+                    @endif
                 </td>
             </tr>
             @endforeach

--- a/resources/views/admin/divisions/partials/table.blade.php
+++ b/resources/views/admin/divisions/partials/table.blade.php
@@ -29,7 +29,9 @@
                 </td>
 
                 <td>
-                    <a href="{{ route('admin.divisions.edit', $division->id) }}" class="btn-rfq btn-sm btn-rfq-secondary edit_page  mr-1">Edit</a>
+                    @if(checkPermission('PRODUCT_DIRECTORY','edit','3'))
+                        <a href="{{ route('admin.divisions.edit', $division->id) }}" class="btn-rfq btn-sm btn-rfq-secondary edit_page  mr-1">Edit</a>
+                    @endif
                 </td>
             </tr>
             @endforeach

--- a/resources/views/admin/users/partials/table.blade.php
+++ b/resources/views/admin/users/partials/table.blade.php
@@ -33,10 +33,11 @@
                     </span>
                 </td>
                 <td>
-                    <a href="{{ route('admin.users.edit', $user->id) }}" class="btn-rfq btn-rfq-secondary btn-sm">
-                         Edit
-                    </a>
-
+                    @if(checkPermission('ADMIN_USERS','edit','3'))
+                        <a href="{{ route('admin.users.edit', $user->id) }}" class="btn-rfq btn-rfq-secondary btn-sm">
+                             Edit
+                        </a>
+                    @endif
                 </td>
             </tr>
         @empty


### PR DESCRIPTION
## Summary
- hide edit links in admin tables unless user has proper permissions

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/rv22/vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68be8a6ccb348327aac0ae8a6ab0a111