### PR TITLE
feat: inline export logic for forward auction reports

### DIFF
--- a/resources/views/admin/forward-auction-report/forward-auction-summary-report.blade.php
+++ b/resources/views/admin/forward-auction-report/forward-auction-summary-report.blade.php
@@ -163,39 +163,117 @@
     </script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/exceljs/4.3.0/exceljs.min.js"></script>
-    <script src="{{ asset('public/assets/xlsx/export.js') }}"></script>
     <script>
         $(document).ready(function() {
-            const exporter = new Exporter({
-                chunkSize: 10000,
-                rowLimitPerSheet: 200000,
-                headers: ["Auction ID", "Product Details", "Buyer Name", "Vendor Name", "Start Date & Time", "Participated"],
-                totalUrl: "{{ route('admin.forward-auctions-summary.exportTotal') }}",
-                batchUrl: "{{ route('admin.forward-auctions-summary.exportBatch') }}",
-                token: "{{ csrf_token() }}",
-                exportName: "forward-auction-report",
-                expButton: '#export-btn',
-                exportProgress: '#export-progress',
-                progressText: '#progress-text',
-                progress: '#progress',
-                fillterReadOnly: '.fillter-form-control',
-                cursorKeys: ['last_auction_id','last_vendor_id'],
-                getParams: function() {
-                    return {
-                        auction_id: $('#auction_id').val(),
-                        vendor_name: $('#vendor_name').val(),
-                        buyer_name: $('#buyer_name').val(),
-                        from_date: $('#from_date').val(),
-                        to_date: $('#to_date').val()
-                    };
-                }
-            });
-
-            $('#export-btn').on('click', function() {
-                exporter.start();
-            });
-
             $('#export-progress').hide();
+
+            let exporting = false;
+
+            $('#export-btn').on('click', function(e) {
+                e.preventDefault();
+                if (exporting) return;
+                exporting = true;
+
+                const chunkSize = 10000;
+                const workbook = new ExcelJS.Workbook();
+                const worksheet = workbook.addWorksheet('Sheet1');
+                worksheet.addRow(["Auction ID", "Product Details", "Buyer Name", "Vendor Name", "Start Date & Time", "Participated"]);
+
+                $('#export-progress').show();
+                $('#progress').css('width', '0%');
+                $('#progress-text').text('0%');
+                $('.fillter-form-control').attr('readonly', true);
+                $(this).attr('disabled', true);
+
+                const filters = {
+                    auction_id: $('#auction_id').val(),
+                    vendor_name: $('#vendor_name').val(),
+                    buyer_name: $('#buyer_name').val(),
+                    from_date: $('#from_date').val(),
+                    to_date: $('#to_date').val()
+                };
+
+                function resetExport() {
+                    $('#export-progress').hide();
+                    $('#progress').css('width', '0%');
+                    $('#progress-text').text('0%');
+                    $('.fillter-form-control').attr('readonly', false);
+                    $('#export-btn').attr('disabled', false);
+                    exporting = false;
+                }
+
+                $.ajax({
+                    url: "{{ route('admin.forward-auctions-summary.exportTotal') }}",
+                    method: 'GET',
+                    data: filters,
+                    success: function(res) {
+                        const total = res.total;
+                        if (!total) {
+                            alert('No data found');
+                            resetExport();
+                            return;
+                        }
+
+                        let fetched = 0;
+                        let lastAuctionId = null;
+                        let lastVendorId = null;
+
+                        const fetchBatch = () => {
+                            const params = Object.assign({}, filters, { limit: chunkSize });
+                            if (lastAuctionId !== null && lastVendorId !== null) {
+                                params.last_auction_id = lastAuctionId;
+                                params.last_vendor_id = lastVendorId;
+                            }
+
+                            $.ajax({
+                                url: "{{ route('admin.forward-auctions-summary.exportBatch') }}",
+                                method: 'GET',
+                                data: params,
+                                success: function(batch) {
+                                    batch.data.forEach(row => worksheet.addRow(row));
+                                    fetched += batch.data.length;
+                                    lastAuctionId = batch.last_auction_id;
+                                    lastVendorId = batch.last_vendor_id;
+
+                                    const percent = Math.round((fetched / total) * 100);
+                                    $('#progress').css('width', percent + '%');
+                                    $('#progress-text').text(percent + '%');
+
+                                    if (fetched < total && batch.data.length > 0) {
+                                        fetchBatch();
+                                    } else {
+                                        workbook.xlsx.writeBuffer().then(buffer => {
+                                            const blob = new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+                                            const url = URL.createObjectURL(blob);
+                                            const a = document.createElement('a');
+                                            a.href = url;
+                                            a.download = 'forward-auction-report_' + Date.now() + '.xlsx';
+                                            document.body.appendChild(a);
+                                            a.click();
+                                            document.body.removeChild(a);
+                                            URL.revokeObjectURL(url);
+                                        }).catch(() => {
+                                            alert('Error generating file');
+                                        }).finally(() => {
+                                            resetExport();
+                                        });
+                                    }
+                                },
+                                error: function() {
+                                    alert('Error fetching data');
+                                    resetExport();
+                                }
+                            });
+                        };
+
+                        fetchBatch();
+                    },
+                    error: function() {
+                        alert('Error fetching total count');
+                        resetExport();
+                    }
+                });
+            });
         });
     </script>
 @endsection


### PR DESCRIPTION
## Summary
- remove `export.js` dependency from forward auction summary view
- add inline ExcelJS export with progress tracking

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68be98ad8c3c8327a1f1e7522f3c4257