### PR TITLE
Optimize Auction RFQ summary report with raw queries

### DIFF
--- a/app/Http/Controllers/Admin/AuctionRFQSummaryReportController.php
+++ b/app/Http/Controllers/Admin/AuctionRFQSummaryReportController.php
@@ -4,115 +4,118 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
-use App\Models\RfqAuction;
+use Illuminate\Support\Facades\DB;
 use App\Traits\HasModulePermission;
+
 class AuctionRFQSummaryReportController extends Controller
 {
     use HasModulePermission;
+
+    private function baseQuery(Request $request)
+    {
+        $query = DB::table('rfq_auctions as ra')
+            ->leftJoin('rfq_vendor_auctions as rva', 'ra.id', '=', 'rva.auction_id')
+            ->leftJoin('vendors as v', 'rva.vendor_id', '=', 'v.user_id')
+            ->leftJoin('users as u', 'v.user_id', '=', 'u.id')
+            ->leftJoin('rfq_auction_variants as rav', 'ra.id', '=', 'rav.auction_id')
+            ->leftJoin('products as p', 'rav.product_id', '=', 'p.id')
+            ->leftJoin('buyers as b', 'ra.buyer_id', '=', 'b.user_id');
+
+        if ($request->filled('buyer_name')) {
+            $query->where('b.legal_name', 'like', '%' . $request->buyer_name . '%');
+        }
+
+        if ($request->filled('from_date') && $request->filled('to_date')) {
+            $query->whereBetween('ra.auction_date', [$request->from_date, $request->to_date]);
+        } elseif ($request->filled('from_date')) {
+            $query->where('ra.auction_date', '>=', $request->from_date);
+        } elseif ($request->filled('to_date')) {
+            $query->where('ra.auction_date', '<=', $request->to_date);
+        }
+
+        return $query;
+    }
+
     public function index(Request $request)
     {
         $this->ensurePermission('VENDOR_REPORTS');
 
-        $query = RfqAuction::with([
-            'rfq_vendor_auction.vendor.user',
-            'rfq_auction_variant.product',
-            'buyer',
-        ]);
-        
-        if ($request->filled('buyer_name'))
-        {
-            $legal_name=$request->buyer_name;
-            $query->whereHas('buyer', function ($q) use ($legal_name) {
-                $q->where('legal_name', 'like', "%$legal_name%");
-            });
-        }
-        // Filter by date range (auction_date)
-        if ($request->filled('from_date') && $request->filled('to_date')) {
-            $query->whereBetween('auction_date', [$request->from_date, $request->to_date]);
-        } elseif ($request->filled('from_date')) {
-            $query->where('auction_date', '>=', $request->from_date);
-        } elseif ($request->filled('to_date')) {
-            $query->where('auction_date', '<=', $request->to_date);
-        }
+        $query = $this->baseQuery($request)->select(
+            'ra.rfq_no',
+            'ra.auction_date',
+            'ra.auction_start_time',
+            'ra.auction_end_time',
+            'b.legal_name as buyer_legal_name',
+            'p.product_name',
+            'v.legal_name as vendor_legal_name',
+            'u.email',
+            'u.mobile',
+            'u.status as vendor_user_status'
+        );
+
         $perPage = $request->input('per_page', 25);
-        $results = $query->orderBy('auction_date', 'desc')->paginate($perPage)->appends($request->all());
-        //$results = $query->orderBy('id')->paginate(25);
-         
+        $results = $query->orderBy('ra.auction_date', 'desc')
+            ->paginate($perPage)
+            ->appends($request->all());
+
         if ($request->ajax()) {
-            return view('admin.reports.partials.auction-rfq-summary-report-table', compact('results'))->render();
+            return view('admin.reports.partials.auction-rfq-summary-report-table', compact('results'))
+                ->render();
         }
+
         return view('admin.reports.auction-rfq-summary-report', compact('results'));
     }
 
     public function exportTotal(Request $request)
     {
-        $query = RfqAuction::with([
-            'rfq_vendor_auction.vendor.user',
-            'rfq_auction_variant.product',
-            'buyer',
-        ]);
-        if ($request->filled('buyer_name'))
-        {
-            $legal_name=$request->buyer_name;
-            $query->whereHas('buyer', function ($q) use ($legal_name) {
-                $q->where('legal_name', 'like', "%$legal_name%");
-            });
-        }
-        // Filter by date range (auction_date)
-        if ($request->filled('from_date') && $request->filled('to_date')) {
-            $query->whereBetween('auction_date', [$request->from_date, $request->to_date]);
-        } elseif ($request->filled('from_date')) {
-            $query->where('auction_date', '>=', $request->from_date);
-        } elseif ($request->filled('to_date')) {
-            $query->where('auction_date', '<=', $request->to_date);
-        }
-        $results = $query->orderBy('auction_date')->get();
-        return response()->json(['total' => $results->count()]);
+        $total = $this->baseQuery($request)->count();
+
+        return response()->json(['total' => $total]);
     }
 
     public function exportBatch(Request $request)
     {
         $offset = intval($request->input('start'));
         $limit = intval($request->input('limit'));
-        $query = RfqAuction::with([
-            'rfq_vendor_auction.vendor.user',
-            'rfq_auction_variant.product',
-            'buyer',
-        ]);
-        if ($request->filled('buyer_name'))
-        {
-            $legal_name=$request->buyer_name;
-            $query->whereHas('buyer', function ($q) use ($legal_name) {
-                $q->where('legal_name', 'like', "%$legal_name%");
-            });
-        }
-        // Filter by date range (auction_date)
-        if ($request->filled('from_date') && $request->filled('to_date')) {
-            $query->whereBetween('auction_date', [$request->from_date, $request->to_date]);
-        } elseif ($request->filled('from_date')) {
-            $query->where('auction_date', '>=', $request->from_date);
-        } elseif ($request->filled('to_date')) {
-            $query->where('auction_date', '<=', $request->to_date);
-        }
-        $data_list = $query->orderBy('auction_date')->skip($offset)->take($limit)->get();
+
+        $query = $this->baseQuery($request)->select(
+            'ra.rfq_no',
+            'ra.auction_date',
+            'ra.auction_start_time',
+            'ra.auction_end_time',
+            'b.legal_name as buyer_legal_name',
+            'p.product_name',
+            'v.legal_name as vendor_legal_name',
+            'u.email',
+            'u.mobile',
+            'u.status as vendor_user_status'
+        );
+
+        $dataList = $query->orderBy('ra.auction_date')
+            ->offset($offset)
+            ->limit($limit)
+            ->get();
+
         $result = [];
-        foreach ($data_list as $value) {
-            $result[]=[
-                ($value->rfq_no??''),
-                ( date('d/m/Y', strtotime($value->auction_date)) ?? ''),
-                ( date('h:i A', strtotime($value->auction_start_time)) ).' To '.( date('h:i A', strtotime($value->auction_end_time)) ),
-                ($value->buyer?->legal_name??''),
-                ($value->rfq_auction_variant->product->product_name ?? ''),
-                ($value->rfq_vendor_auction?->vendor?->legal_name ?? ''),
-                ($value->rfq_vendor_auction?->vendor?->user?->email ?? ''),
-                ($value->rfq_vendor_auction?->vendor?->user?->mobile ?? ''),
-                ((($status = $value->rfq_vendor_auction?->vendor?->user?->status) === 1)
+        foreach ($dataList as $value) {
+            $result[] = [
+                $value->rfq_no ?? '',
+                date('d/m/Y', strtotime($value->auction_date)) ?? '',
+                date('h:i A', strtotime($value->auction_start_time)) . ' To ' .
+                    date('h:i A', strtotime($value->auction_end_time)),
+                $value->buyer_legal_name ?? '',
+                $value->product_name ?? '',
+                $value->vendor_legal_name ?? '',
+                $value->email ?? '',
+                $value->mobile ?? '',
+                $value->vendor_user_status == 1
                     ? 'Active'
-                    : ($status === 0 ? 'Inactive' : '')),
+                    : ($value->vendor_user_status == 0 ? 'Inactive' : ''),
                 '',
-               ''];
+                '',
+            ];
         }
+
         return response()->json(['data' => $result]);
     }
-
 }

--- a/resources/views/admin/reports/partials/auction-rfq-summary-report-table.blade.php
+++ b/resources/views/admin/reports/partials/auction-rfq-summary-report-table.blade.php
@@ -16,29 +16,28 @@
             </tr>
         </thead>
         <tbody>
-            @php
-                $i = ($results->currentPage() - 1) * $results->perPage() + 1;
-            @endphp
-            @forelse ($results as $result)
-                <tr>
-                    <td>{{ $result->rfq_no??''}}</td>
-                    <td>{{ date('d/m/Y', strtotime($result->auction_date)) ?? ''}}</td>
-                    <td>{{ date('h:i A', strtotime($result->auction_start_time)) }} To {{ date('h:i A', strtotime($result->auction_end_time)) }}</td>
-                    <td>{{$result->buyer?->legal_name??''}}</td>
-                    <td>{{$result->rfq_auction_variant->product->product_name ?? ''}}</td>
-                    <td>{{$result->rfq_vendor_auction?->vendor?->legal_name ?? ''}}</td>
-                    <td>{{$result->rfq_vendor_auction?->vendor?->user?->email ?? ''}}</td>
-                    <td>{{$result->rfq_vendor_auction?->vendor?->user?->mobile ?? ''}}</td>
-                    @php($status = $result->rfq_vendor_auction?->vendor?->user?->status)
-                    <td>{{ $status === 1 ? 'Active' : ($status === 0 ? 'Inactive' : '') }}</td>
-                    <td></td>
-                    <td></td>
-                </tr>
-            @empty
-                <tr>
-                    <td colspan="12" class="text-center">No data available in table</td>
-                </tr>
-            @endforelse
+        @php
+            $i = ($results->currentPage() - 1) * $results->perPage() + 1;
+        @endphp
+        @forelse ($results as $result)
+            <tr>
+                <td>{{ $result->rfq_no ?? '' }}</td>
+                <td>{{ date('d/m/Y', strtotime($result->auction_date)) ?? '' }}</td>
+                <td>{{ date('h:i A', strtotime($result->auction_start_time)) }} To {{ date('h:i A', strtotime($result->auction_end_time)) }}</td>
+                <td>{{ $result->buyer_legal_name ?? '' }}</td>
+                <td>{{ $result->product_name ?? '' }}</td>
+                <td>{{ $result->vendor_legal_name ?? '' }}</td>
+                <td>{{ $result->email ?? '' }}</td>
+                <td>{{ $result->mobile ?? '' }}</td>
+                <td>{{ $result->vendor_user_status == 1 ? 'Active' : ($result->vendor_user_status == 0 ? 'Inactive' : '') }}</td>
+                <td></td>
+                <td></td>
+            </tr>
+        @empty
+            <tr>
+                <td colspan="12" class="text-center">No data available in table</td>
+            </tr>
+        @endforelse
         </tbody>
     </table>
 </div>


### PR DESCRIPTION
## Summary
- Replace Eloquent model usage in AuctionRFQSummaryReportController with raw query builder joins for improved performance on large datasets
- Update auction RFQ summary table view to read flattened result fields from raw queries
- Factor common filtering logic into a reusable `baseQuery` method to avoid repetition and handle heavy data efficiently

## Testing
- `php -l app/Http/Controllers/Admin/AuctionRFQSummaryReportController.php`
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*
- `composer install` *(fails: curl error 56 while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68bea8b4dee88327b5a0bcb5fa0c400a