### PR TITLE
Fix GSTIN/VAT document validation handling

### DIFF
--- a/app/Http/Controllers/Vendor/VendorProfileController.php
+++ b/app/Http/Controllers/Vendor/VendorProfileController.php
@@ -460,7 +460,7 @@ class VendorProfileController extends Controller
                     }
                 }
             ],
-            'gstin_document' => ['required_without:gstin_document_old', 'file', 'mimes:jpg,jpeg,pdf', 'max:2048'],
+            'gstin_document' => ['required_without:gstin_document_old', 'file', 'mimes:jpg,jpeg,pdf,png', 'max:2048'],
             'website' => ['nullable', 'url'],
             'company_name1' => ['required', 'string', 'max:255'],
             'company_name2' => ['required', 'string', 'max:255'],

--- a/resources/views/vendor/setting/profile.blade.php
+++ b/resources/views/vendor/setting/profile.blade.php
@@ -221,7 +221,8 @@
                                         </label>
 
                                         <div class="simple-file-upload">
-                                            <input type="file" onchange="validateFile(this, 'JPG/JPEG/PDF')"
+                                            <input type="hidden" name="gstin_document_old" value="{{ $vendor->gstin_document }}">
+                                            <input type="file" onchange="validateFile(this, 'JPG/JPEG/PDF/PNG')"
                                                 class="{{ $vendor->gstin_document == '' || $vendor->gstin_document == null ? 'required-file' : '' }} real-file-input mng-input"
                                                 name="gstin_document" style="display: none;">
                                             <div class="file-display-box form-control text-start font-size-12 text-dark"


### PR DESCRIPTION
## Summary
- Preserve existing GSTIN/VAT document when updating vendor profile
- Allow PNG uploads for GSTIN/VAT document and client-side validation

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68c150698f10832793c5f817fd9997ca