### PR TITLE
Handle vendor attachments and brand by product

### DIFF
--- a/app/Http/Controllers/Vendor/RfqReceivedController.php
+++ b/app/Http/Controllers/Vendor/RfqReceivedController.php
@@ -372,12 +372,22 @@ class RfqReceivedController extends Controller
         $action = $request->input('action');            // 'save' or 'submit'
         $status = ($action === 'save') ? '2' : '1';     // 2 = draft, 1 = submitted
 
-        // Arrays from form (indexed by variantId)
+        // Arrays from form
+        // Price related fields remain indexed by variantId
         $prices      = $request->input('price', []);
         $mrps        = $request->input('mrp', []);
         $discounts   = $request->input('disc', []);
         $specs       = $request->input('vendor_spec', []);
-        $sellerbrand = $request->input('sellerbrand', []);
+
+        // Brand & attachment are submitted against product_id now
+        $sellerbrand = $request->input('sellerbrand', []); // keyed by productId
+
+        // Map variantId => productId for quick lookup
+        $variantProductMap = RfqProductVariant::whereIn('id', array_keys($prices))
+            ->pluck('product_id', 'id');
+
+        // Track uploaded attachment path per product
+        $productAttachmentMap = [];
 
          DB::beginTransaction();
          try {
@@ -386,42 +396,50 @@ class RfqReceivedController extends Controller
                     continue;
                 }
 
-                // Find latest existing quotation (to keep old attachment if not replaced)
+                $productId = $variantProductMap[$variantId] ?? null;
+
+                // Find latest existing quotation for this variant
                 $existingQuotation = RfqVendorQuotation::where([
                     'vendor_id'              => $vendor_id,
                     'rfq_id'                 => $rfq_id,
                     'rfq_product_variant_id' => $variantId,
                 ])->latest()->first();
 
-                $attachmentPath = $existingQuotation->vendor_attachment_file ?? null;
+                // Determine attachment path per product
+                if (!array_key_exists($productId, $productAttachmentMap)) {
+                    $attachmentPath = $existingQuotation->vendor_attachment_file ?? null;
 
-                // Agar user ne explicitly delete kar diya (existing_vendor_attachment blank bheja)
-                if ($request->input("existing_vendor_attachment.$variantId") == ""  && !empty($attachmentPath)) {
-                    // Purani file delete kar do
-                    if ($attachmentPath && file_exists(public_path('uploads/rfq-attachment/' . $attachmentPath))) {
-                        @unlink(public_path('uploads/rfq-attachment/' . $attachmentPath));
+                    // If user removed existing attachment
+                    if ($request->input("existing_vendor_attachment.$productId") === "" && !empty($attachmentPath)) {
+                        if ($attachmentPath && file_exists(public_path('uploads/rfq-attachment/' . $attachmentPath))) {
+                            @unlink(public_path('uploads/rfq-attachment/' . $attachmentPath));
+                        }
+                        $attachmentPath = null;
                     }
-                    $attachmentPath = null; // db me bhi null save hoga
+
+                    // Handle file upload (expects input name: vendor_attachment[<productId>])
+                    if ($request->hasFile("vendor_attachment.$productId")) {
+                        $file = $request->file("vendor_attachment.$productId");
+
+                        // Delete old file if exists
+                        if ($attachmentPath && file_exists(public_path('uploads/rfq-attachment/' . $attachmentPath))) {
+                            @unlink(public_path('uploads/rfq-attachment/' . $attachmentPath));
+                        }
+
+                        $uploadPath = public_path('uploads/rfq-attachment');
+                        if (!file_exists($uploadPath)) {
+                            mkdir($uploadPath, 0755, true);
+                        }
+
+                        $fileName = 'rfq_' . time() . '_' . $productId . '.' . $file->getClientOriginalExtension();
+                        $file->move($uploadPath, $fileName);
+                        $attachmentPath = $fileName;
+                    }
+
+                    $productAttachmentMap[$productId] = $attachmentPath;
                 }
 
-                // Handle file upload (expects input name: vendor_attachment[<variantId>])
-                if ($request->hasFile("vendor_attachment.$variantId")) {
-                    $file = $request->file("vendor_attachment.$variantId");
-
-                    // Delete old file if exists
-                    if ($attachmentPath && file_exists(public_path('uploads/rfq-attachment/' . $attachmentPath))) {
-                        @unlink(public_path('uploads/rfq-attachment/' . $attachmentPath));
-                    }
-
-                    $uploadPath = public_path('uploads/rfq-attachment');
-                    if (!file_exists($uploadPath)) {
-                        mkdir($uploadPath, 0755, true);
-                    }
-
-                    $fileName = 'rfq_' . time() . '_' . $variantId . '.' . $file->getClientOriginalExtension();
-                    $file->move($uploadPath, $fileName);
-                    $attachmentPath = $fileName;
-                }
+                $attachmentPath = $productAttachmentMap[$productId] ?? null;
 
                 // If saving draft, remove previous drafts for this variant (status = 2)
                 if ($action === 'save') {
@@ -445,7 +463,7 @@ class RfqReceivedController extends Controller
                     'buyer_price'            => 0,
                     'specification'          => $specs[$variantId] ?? null,
                     'vendor_attachment_file' => $attachmentPath,
-                    'vendor_brand'           => $sellerbrand[$variantId] ?? null,
+                    'vendor_brand'           => $sellerbrand[$productId] ?? null,
                     'vendor_remarks'         => $request->input('seller-remarks'),
                     'vendor_additional_remarks' => $request->input('Seller-Additional-Remarks'),
                     'vendor_price_basis'        => $request->input('vendor_price_basis'),

--- a/resources/views/vendor/rfq-received/rfq_details.blade.php
+++ b/resources/views/vendor/rfq-received/rfq_details.blade.php
@@ -206,11 +206,6 @@ function IND_amount_format($amount) {
                             </thead>
                             <tbody>
                                 @foreach ($productVariants as $vIndex => $variant)
-                                @php
-                                 echo "<pre>";
-                                 print_r($variant); die;
-                                @endphp
-
                                 <tr>
                                     <td>{{ $vIndex + 1 }}</td>
                                     <td>{{ $variant->specification }}</td>
@@ -385,7 +380,7 @@ function IND_amount_format($amount) {
 
 
                         <div class="col-md-4 mb-3">
-                          <div class="upload-field" data-variant="{{ $productVariants[0]->id }}">
+                          <div class="upload-field" data-product="{{ $product->product_id }}">
                            <!--  <div class="d-flex justify-content-end mb-1">
                               <span class="upload-label js-upload-trigger">UPLOAD FILE</span>
                             </div> -->
@@ -402,8 +397,8 @@ function IND_amount_format($amount) {
 
                               <!-- Hidden real file input -->
                               <input type="file"
-                                     id="uploadFile_{{ $productVariants[0]->id }}"
-                                     name="vendor_attachment[{{ $productVariants[0]->id }}]"
+                                     id="uploadFile_{{ $product->product_id }}"
+                                     name="vendor_attachment[{{ $product->product_id }}]"
                                      class="d-none vendor-attachment"
                                      accept=".pdf,.doc,.docx,.xls,.xlsx,.jpg,.jpeg,.png"
                                      {{ $product->is_product == 'no' ? 'disabled' : '' }} />
@@ -430,7 +425,7 @@ function IND_amount_format($amount) {
                                 <i class="bi bi-x-circle text-danger file-remove js-remove-existing"
                                    title="Remove"></i>
                                 <input type="hidden"
-                                       name="existing_vendor_attachment[{{ $productVariants[0]->id }}]"
+                                       name="existing_vendor_attachment[{{ $product->product_id }}]"
                                        value="{{ $existingFile }}">
                               @endif
                               <!-- new selection will appear here -->
@@ -453,7 +448,7 @@ function IND_amount_format($amount) {
                                 </span>
                                 <div class="form-floating">
                                     <input type="text" class="form-control" id="sellerBrand"
-                                        name="sellerbrand[{{ $productVariants[0]->id }}]"
+                                        name="sellerbrand[{{ $product->product_id }}]"
                                         value="{{ optional($productVariants[0]->vendor_quotation)->vendor_brand ?? '' }}"
                                         placeholder="Seller Brand" {{ $product->is_product == 'no' ? 'disabled' : '' }}>
                                     <label for="sellerBrand">Seller Brand</label>


### PR DESCRIPTION
## Summary
- Submit vendor brand and attachment against product IDs instead of variant IDs
- Cleaned RFQ details view to remove debug and align form fields with product-based inputs

## Testing
- ❌ `vendor/bin/phpunit` *(phpunit missing)*
- ❌ `phpunit` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c168e5e0832793227864b61f8801