### PR TITLE
Handle GST requirement for international vendors

### DIFF
--- a/app/Http/Controllers/Vendor/VendorProductController.php
+++ b/app/Http/Controllers/Vendor/VendorProductController.php
@@ -200,14 +200,21 @@ class VendorProductController extends Controller
     }
 
     public function store(Request $request)
-    {   
-        
-        $validator = Validator::make($request->all(), [
+    {
+
+        $isNationalVendor = is_national() == 1;
+
+        $rules = [
             'product_name' => 'required',
             'description' => 'required',
             'hsn_code' => 'required|digits_between:2,8',
-            'gst' => 'required',
-        ]);
+        ];
+
+        if ($isNationalVendor) {
+            $rules['gst'] = 'required';
+        }
+
+        $validator = Validator::make($request->all(), $rules);
 
         if ($validator->fails()) {
             return response()->json([
@@ -280,7 +287,7 @@ class VendorProductController extends Controller
             }
             $product->description = strip_tags($request->description, '<a><b><h1><p><div><strong><ul><li>');
             $product->dealer_type_id = $request->dealer_type;
-            $product->gst_id = $request->gst;
+            $product->gst_id = $isNationalVendor ? $request->gst : 1;
             $product->hsn_code = $request->hsn_code;
             $product->dealership = $request->dealership;
             $product->brand = $request->brand;
@@ -379,12 +386,19 @@ class VendorProductController extends Controller
         $vendorId = getParentUserId();
         $product = VendorProduct::findOrFail($id);
 
-        $validator = Validator::make($request->all(), [
+        $isNationalVendor = is_national() == 1;
+
+        $rules = [
             'product_name' => 'required',
             'description' => 'required',
             'hsn_code' => 'required|digits_between:2,8',
-            'gst' => 'required',
-        ]);
+        ];
+
+        if ($isNationalVendor) {
+            $rules['gst'] = 'required';
+        }
+
+        $validator = Validator::make($request->all(), $rules);
 
         if ($validator->fails()) {
             return response()->json([
@@ -420,7 +434,7 @@ class VendorProductController extends Controller
             $product->product_id = $request->product_id ?? 0;  // Set to 0 if product_id is empty
             $product->description = strip_tags($request->description, '<a><b><h1><p><div><strong><ul><li>');
             $product->dealer_type_id = $request->dealer_type ?? '1';
-            $product->gst_id = $request->gst;
+            $product->gst_id = $isNationalVendor ? $request->gst : 1;
             $product->hsn_code = $request->hsn_code;
             $product->dealership = $request->dealership;
             $product->brand = $request->brand;

--- a/resources/views/vendor/products/create.blade.php
+++ b/resources/views/vendor/products/create.blade.php
@@ -127,7 +127,10 @@
           </div>
 
           <!-- GST/Sales Tax Rate -->
-          @if (is_national() == 1)
+          @php
+              $isNationalVendor = is_national() == 1;
+          @endphp
+          @if ($isNationalVendor)
             <!-- Show GST dropdown -->
             <div class="row gx-3 align-items-center mb-4">
                 <div class="col-sm-3">
@@ -147,7 +150,7 @@
             </div>
           @else
               <!-- Hidden GST field with value 1 -->
-              <input type="hidden" name="gst" id="product_gst" value="1">
+              <input type="hidden" name="gst" id="product_gst" value="">
           @endif
 
 
@@ -360,6 +363,8 @@ $(document).ready(function () {
     
 
 
+    const isNationalVendor = @json($isNationalVendor);
+
     $('#productForm').submit(function (e) {
       e.preventDefault();
       $('span.error-text').text('');
@@ -394,7 +399,7 @@ $(document).ready(function () {
           hasErrors = true;
       }
 
-      if (!product_gst) {
+      if (isNationalVendor && !product_gst) {
           $('.product-gst-error').text('GST/Sales Tax Rate is required***');
           hasErrors = true;
       }

--- a/resources/views/vendor/products/edit.blade.php
+++ b/resources/views/vendor/products/edit.blade.php
@@ -123,7 +123,10 @@
           </div>
 
           <!-- GST/Sales Tax Rate Dropdown -->
-          @if (is_national() == 1)
+          @php
+              $isNationalVendor = is_national() == 1;
+          @endphp
+          @if ($isNationalVendor)
           <div class="row gx-3 align-items-center mb-4">
             <div class="col-sm-3">
               <label class="col-form-label">GST/Sales Tax Rate <span class="text-danger">*</span></label>
@@ -142,7 +145,7 @@
           </div>
           @else
               <!-- Hidden GST field with value 1 -->
-              <input type="hidden" name="gst" id="product_gst" value="1">
+              <input type="hidden" name="gst" id="product_gst" value="{{ $product->gst_id ?? '' }}">
           @endif
 
 
@@ -349,6 +352,8 @@ $(document).ready(function () {
     initEditor('#product_description', '.prod-des-count', '#product-description-error', true);
     initEditor('#product_specifications', '.spec-char-count');
 
+    const isNationalVendor = @json($isNationalVendor);
+
     $('#productForm').submit(function (e) {
       e.preventDefault();
       const $submitBtn = $('#submitBtn');
@@ -389,7 +394,7 @@ $(document).ready(function () {
           hasErrors = true;
       }
 
-      if (!product_gst) {
+      if (isNationalVendor && !product_gst) {
           $('.product-gst-error').text('GST/Sales Tax Rate is required***');
           hasErrors = true;
       }


### PR DESCRIPTION
## Summary
- skip showing the GST dropdown for international vendors while keeping an empty hidden field
- only require GST selection for national vendors and default internationals to the zero-tax option on save
- guard client-side validation so international vendors do not see GST errors during product create/update

## Testing
- php artisan test *(fails: vendor directory missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6a084a4c83279def8604c014edef