### PR TITLE
Use vendor legal name in admin product lists

### DIFF
--- a/app/Http/Controllers/Admin/BulkApprovalProductsController.php
+++ b/app/Http/Controllers/Admin/BulkApprovalProductsController.php
@@ -34,8 +34,8 @@ class BulkApprovalProductsController extends Controller
         }
 
         if ($request->filled('vendor_name')) {
-            $subQuery->whereHas('vendor', function ($q) use ($request) {
-                $q->where('name', 'like', '%' . $request->input('vendor_name') . '%');
+            $subQuery->whereHas('vendor_profile', function ($q) use ($request) {
+                $q->where('legal_name', 'like', '%' . $request->input('vendor_name') . '%');
             });
         }
 
@@ -45,7 +45,7 @@ class BulkApprovalProductsController extends Controller
 
         $groupedIds = $subQuery->groupBy('group_id')->pluck('id');
 
-        $query = VendorProduct::with(['vendor','receivedfrom'])
+        $query = VendorProduct::with(['vendor','vendor_profile','receivedfrom'])
             ->whereIn('id', $groupedIds);
 
         $perPage = $request->input('per_page', 25);

--- a/app/Http/Controllers/Admin/EditProductRequestController.php
+++ b/app/Http/Controllers/Admin/EditProductRequestController.php
@@ -19,7 +19,7 @@ class EditProductRequestController extends Controller
     {
         $this->ensurePermission('EDIT_PRODUCT');
 
-        $query = VendorProduct::with(['vendor', 'product', 'receivedfrom'])
+        $query = VendorProduct::with(['vendor', 'vendor_profile', 'product', 'receivedfrom'])
             ->where('edit_status', 1) // 1 => Edit Request
             ->where('approval_status', '!=', 1)
             ->whereNull('group_id')->orderBy('updated_at', 'DESC'); // <-- NEW: Orders by latest updates first;
@@ -31,8 +31,8 @@ class EditProductRequestController extends Controller
         }
 
         if ($request->filled('vendor_name')) {
-            $query->whereHas('vendor', function ($q) use ($request) {
-                $q->where('name', 'like', '%' . $request->input('vendor_name') . '%');
+            $query->whereHas('vendor_profile', function ($q) use ($request) {
+                $q->where('legal_name', 'like', '%' . $request->input('vendor_name') . '%');
             });
         }
 

--- a/app/Http/Controllers/Admin/NewProductRequestController.php
+++ b/app/Http/Controllers/Admin/NewProductRequestController.php
@@ -21,7 +21,7 @@ class NewProductRequestController extends Controller
     {
         $this->ensurePermission('NEW_PRODUCT_REQUEST');
 
-        $query = VendorProduct::with(['vendor','receivedfrom'])
+        $query = VendorProduct::with(['vendor','vendor_profile','receivedfrom'])
             ->where('edit_status', 2) // 1 => New Request
             ->where('approval_status', '!=', 1)
             ->whereNull('group_id')->orderBy('updated_at', 'DESC'); // <-- NEW: Orders by latest updates first;
@@ -31,8 +31,8 @@ class NewProductRequestController extends Controller
         }
 
         if ($request->filled('vendor_name')) {
-            $query->whereHas('vendor', function ($q) use ($request) {
-                $q->where('name', 'like', '%' . $request->input('vendor_name') . '%');
+            $query->whereHas('vendor_profile', function ($q) use ($request) {
+                $q->where('legal_name', 'like', '%' . $request->input('vendor_name') . '%');
             });
         }
 

--- a/app/Http/Controllers/Admin/ProductApprovalController.php
+++ b/app/Http/Controllers/Admin/ProductApprovalController.php
@@ -20,7 +20,7 @@ class ProductApprovalController extends Controller
     {
         $this->ensurePermission('PRODUCTS_FOR_APPROVAL');
 
-        $query = VendorProduct::with(['vendor', 'product' , 'receivedfrom'])
+        $query = VendorProduct::with(['vendor', 'vendor_profile', 'product' , 'receivedfrom'])
             ->where('edit_status', 3)
             ->where('approval_status', '!=', 1)
             ->whereNull('group_id'); // equivalent to IS NULL
@@ -32,8 +32,8 @@ class ProductApprovalController extends Controller
         }
 
         if ($request->filled('vendor_name')) {
-            $query->whereHas('vendor', function ($q) use ($request) {
-                $q->where('name', 'like', '%' . $request->input('vendor_name') . '%');
+            $query->whereHas('vendor_profile', function ($q) use ($request) {
+                $q->where('legal_name', 'like', '%' . $request->input('vendor_name') . '%');
             });
         }
 

--- a/app/Http/Controllers/Admin/VerifiedProductController.php
+++ b/app/Http/Controllers/Admin/VerifiedProductController.php
@@ -47,7 +47,7 @@ class VerifiedProductController extends Controller
         $this->ensurePermission('ALL_VERIFIED_PRODUCTS');
 
         // slected column
-        $query = VendorProduct::with(['vendor', 'product'])->where('approval_status', 1)->orderBy('updated_at', 'desc'); // Order by updated_at in descending order
+        $query = VendorProduct::with(['vendor', 'vendor_profile', 'product'])->where('approval_status', 1)->orderBy('updated_at', 'desc'); // Order by updated_at in descending order
         if ($request->filled('product_name')) {
             $query->whereHas('product', function ($q) use ($request) {
                 $q->where('product_name', 'like', '%' . $request->input('product_name') . '%');
@@ -55,8 +55,8 @@ class VerifiedProductController extends Controller
         }
 
         if ($request->filled('vendor_name')) {
-            $query->whereHas('vendor', function ($q) use ($request) {
-                $q->where('name', 'like', '%' . $request->input('vendor_name') . '%');
+            $query->whereHas('vendor_profile', function ($q) use ($request) {
+                $q->where('legal_name', 'like', '%' . $request->input('vendor_name') . '%');
             });
         }
 

--- a/resources/views/admin/bulk-approval-products/partials/table.blade.php
+++ b/resources/views/admin/bulk-approval-products/partials/table.blade.php
@@ -22,7 +22,7 @@
         @forelse ($products as $product)
             <tr>
                 <td>{{ $i++ }}</td>
-                <td class="text-wrap keep-word">{{ $product->vendor->name ?? '-' }}</td>
+                <td class="text-wrap keep-word">{{ optional($product->vendor_profile)->legal_name ?? '-' }}</td>
                 <td class="text-wrap keep-word">{{ $product->receivedfrom->name ?? '-' }}</td>
                 <td class="text-wrap keep-word">{{ $product->product->product_name ?? '-' }}</td>
                 <td>{{ \Carbon\Carbon::parse($product->created_at)->format('d/m/Y') }}</td>

--- a/resources/views/admin/edit-product-requests/partials/table.blade.php
+++ b/resources/views/admin/edit-product-requests/partials/table.blade.php
@@ -22,7 +22,7 @@
         @forelse ($products as $product)
             <tr>
                 <td>{{ $i++ }}</td>
-                <td>{{ $product->vendor->name ?? '-' }}</td>
+                <td>{{ optional($product->vendor_profile)->legal_name ?? '-' }}</td>
                 <td>{{ $product->receivedfrom->name ?? '-' }}</td>
                 <td>{{ $product->product->product_name ?? '-' }}</td>
                 <td>{{ \Carbon\Carbon::parse($product->created_at)->format('d/m/Y') }}</td>

--- a/resources/views/admin/new-product-requests/partials/table.blade.php
+++ b/resources/views/admin/new-product-requests/partials/table.blade.php
@@ -23,7 +23,7 @@
         @forelse ($products as $product)
             <tr>
                 <td>{{ $i++ }}</td>
-                <td>{{ $product->vendor->name ?? '-' }}</td>
+                <td>{{ optional($product->vendor_profile)->legal_name ?? '-' }}</td>
                 <td class="text-wrap keep-word">{{ $product->receivedfrom->name ?? '-' }}</td>
                 <td class="text-wrap keep-word">{{ $product->product_name ?? '-' }}</td>
                 <td><button class="btn-rfq btn-sm btn-rfq-danger btn-delete-product" data-id="{{ $product->id }}">Delete</button></td>

--- a/resources/views/admin/products-for-approval/partials/table.blade.php
+++ b/resources/views/admin/products-for-approval/partials/table.blade.php
@@ -22,7 +22,7 @@
         @forelse ($products as $product)
             <tr>
                 <td>{{ $i++ }}</td>
-                <td>{{ $product->vendor->name ?? '-' }}</td>
+                <td>{{ optional($product->vendor_profile)->legal_name ?? '-' }}</td>
                 <td>{{ $product->receivedfrom->name ?? '-' }}</td>
                 <td>{{ $product->product->product_name ?? '-' }}</td>
                 <td>{{ \Carbon\Carbon::parse($product->created_at)->format('d/m/Y') }}</td>

--- a/resources/views/admin/verified-products/index.blade.php
+++ b/resources/views/admin/verified-products/index.blade.php
@@ -63,7 +63,7 @@
                                         <div class="input-group">
                                             <span class="input-group-text"><i class="bi bi-journal-text"></i></span>
                                             <div class="form-floating">
-                                                <input type="text" name="vendor_name" id="vendorName" class="form-control fillter-form-control" value="{{ request('product_name') }}" placeholder="Vendor Name">
+                                                <input type="text" name="vendor_name" id="vendorName" class="form-control fillter-form-control" value="{{ request('vendor_name') }}" placeholder="Vendor Name">
                                                 <label for="vendorName">Vendor Name</label>
                                             </div>
                                         </div>

--- a/resources/views/admin/verified-products/partials/table.blade.php
+++ b/resources/views/admin/verified-products/partials/table.blade.php
@@ -24,7 +24,7 @@
                     <input type="checkbox" class="product-checkbox" value="{{ $product->id }}" />
                 </td>
                 <td>{{ $i++ }}</td> {{-- S.No. --}}
-                <td>{{ $product->vendor->name ?? '' }}</td>
+                <td>{{ optional($product->vendor_profile)->legal_name ?? '-' }}</td>
                 <td>{{ $product->product->product_name ?? '' }}</td>
                 <td>
                     <button class="btn-style btn-style-danger btn-delete-product" data-id="{{ $product->id }}">Delete</button>


### PR DESCRIPTION
## Summary
- display each vendor's legal name on verified, approval, and request product tables
- filter vendor name searches by the legal name stored on vendor profiles
- fix the verified products vendor search field to keep the entered value

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca6f6c29d083279261c1b0278dcd6b