### PR TITLE
Use product_alias table for vendor alias management

### DIFF
--- a/app/Http/Controllers/Admin/EditProductRequestController.php
+++ b/app/Http/Controllers/Admin/EditProductRequestController.php
@@ -181,9 +181,9 @@ class EditProductRequestController extends Controller
 
             // Update Tags/Aliases
             if (!empty($request->tag)) {
-                DB::table('tbl_prod_alias')
-                    ->where('prod_id', $request->prod_id)
-                    ->where('vend_id', $request->vend_id)
+                DB::table('product_alias')
+                    ->where('product_id', $request->prod_id)
+                    ->where('vendor_id', $request->vend_id)
                     ->where('alias_of', 2)
                     ->delete();
 
@@ -192,8 +192,8 @@ class EditProductRequestController extends Controller
 
                 foreach ($tags as $tag) {
                     $aliasData[] = [
-                        'prod_id' => $request->prod_id,
-                        'vend_id' => $request->vend_id,
+                        'product_id' => $request->prod_id,
+                        'vendor_id' => $request->vend_id,
                         'alias' => htmlspecialchars(strtoupper(substr($tag, 0, 255)), ENT_QUOTES),
                         'alias_of' => 2,
                         'is_new' => 1,
@@ -203,7 +203,7 @@ class EditProductRequestController extends Controller
                 }
 
                 if (!empty($aliasData)) {
-                    DB::table('tbl_prod_alias')->insert($aliasData);
+                    DB::table('product_alias')->insert($aliasData);
                 }
             }
 

--- a/app/Http/Controllers/Admin/NewProductRequestController.php
+++ b/app/Http/Controllers/Admin/NewProductRequestController.php
@@ -270,9 +270,9 @@ class NewProductRequestController extends Controller
 
             // Tags / Aliases
             if (!empty($request->tag)) {
-                DB::table('tbl_prod_alias')
-                    ->where('prod_id', $prod_id)
-                    ->where('vend_id', $request->vend_id)
+                DB::table('product_alias')
+                    ->where('product_id', $prod_id)
+                    ->where('vendor_id', $request->vend_id)
                     ->where('alias_of', 2)
                     ->delete();
 
@@ -281,8 +281,8 @@ class NewProductRequestController extends Controller
 
                 foreach ($tags as $tag) {
                     $aliasData[] = [
-                        'prod_id' => $prod_id,
-                        'vend_id' => $request->vend_id,
+                        'product_id' => $prod_id,
+                        'vendor_id' => $request->vend_id,
                         'alias' => htmlspecialchars(strtoupper(substr($tag, 0, 255)), ENT_QUOTES),
                         'alias_of' => 2,
                         'is_new' => 1,
@@ -292,7 +292,7 @@ class NewProductRequestController extends Controller
                 }
 
                 if (!empty($aliasData)) {
-                    DB::table('tbl_prod_alias')->insert($aliasData);
+                    DB::table('product_alias')->insert($aliasData);
                 }
             }
 
@@ -408,9 +408,9 @@ class NewProductRequestController extends Controller
 
             // Update Tags/Aliases
             if (!empty($request->tag)) {
-                DB::table('tbl_prod_alias')
-                    ->where('prod_id', $request->prod_id)
-                    ->where('vend_id', $request->vend_id)
+                DB::table('product_alias')
+                    ->where('product_id', $request->prod_id)
+                    ->where('vendor_id', $request->vend_id)
                     ->where('alias_of', 2)
                     ->delete();
 
@@ -419,8 +419,8 @@ class NewProductRequestController extends Controller
 
                 foreach ($tags as $tag) {
                     $aliasData[] = [
-                        'prod_id' => $request->prod_id,
-                        'vend_id' => $request->vend_id,
+                        'product_id' => $request->prod_id,
+                        'vendor_id' => $request->vend_id,
                         'alias' => htmlspecialchars(strtoupper(substr($tag, 0, 255)), ENT_QUOTES),
                         'alias_of' => 2,
                         'is_new' => 1,
@@ -430,7 +430,7 @@ class NewProductRequestController extends Controller
                 }
 
                 if (!empty($aliasData)) {
-                    DB::table('tbl_prod_alias')->insert($aliasData);
+                    DB::table('product_alias')->insert($aliasData);
                 }
             }
 


### PR DESCRIPTION
## Summary
- update admin new product request handling to read and write vendor aliases from the product_alias table
- align edit product request alias persistence with the product_alias schema

## Testing
- php artisan test *(fails: vendor/autoload.php missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cb013d223c8327b81694a96fc83fc0