### PR TITLE
Fix missing created_by_vendor column in verified products query

### DIFF
--- a/app/Http/Controllers/Admin/VerifiedProductController.php
+++ b/app/Http/Controllers/Admin/VerifiedProductController.php
@@ -61,7 +61,7 @@ class VerifiedProductController extends Controller
             ->select([
                 'vp.id',
                 'vp.vendor_status',
-                'vp.created_by_vendor',
+                DB::raw("CASE WHEN vp.added_from IN ('1','2','3','4','5') THEN 1 ELSE 0 END AS created_by_vendor"),
                 'vp.updated_at',
                 'p.product_name',
                 'v.legal_name as vendor_legal_name',


### PR DESCRIPTION
## Summary
- derive the created_by_vendor flag in the verified products listing using the added_from source values

## Testing
- php artisan test *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68cba13887fc83278663d77cf67333bb